### PR TITLE
moved earlier in sub_calc_bio_uptake, where DOM fraction is calculated

### DIFF
--- a/genie-biogem/src/fortran/biogem_box.f90
+++ b/genie-biogem/src/fortran/biogem_box.f90
@@ -612,6 +612,41 @@ CONTAINS
     end SELECT
     diag_bio(idiag_bio_kT,dum_i,dum_j) = dum_dt*loc_kT
 
+    ! *** SET DOM FRACTION ******************************************************************************************************* !
+    SELECT CASE (par_bio_prodopt)
+    case (                        &
+         & 'bio_P',               &
+         & 'bio_PFe',             &
+         & 'bio_PFeSi'            &
+         & )
+!!!loc_bio_red_DOMfrac = (1.0 - 0.5/(par_bio_kT0*exp(loc_TC/par_bio_kT_eT)))*par_bio_red_DOMfrac
+       loc_bio_red_DOMfrac = par_bio_red_DOMfrac
+    case default
+       loc_bio_red_DOMfrac = par_bio_red_DOMfrac
+    end SELECT
+
+    ! *** SET RDOM FRACTION ****************************************************************************************************** !
+    SELECT CASE (par_bio_prodopt)
+    case (                        &
+         & 'bio_P',               &
+         & 'bio_PFe',             &
+         & 'bio_PFeSi'            &
+         & )
+!!!loc_bio_red_RDOMfrac = (1.0 - 0.5/(par_bio_kT0*exp(loc_TC/par_bio_kT_eT)))*par_bio_red_RDOMfrac
+       loc_bio_red_RDOMfrac = par_bio_red_RDOMfrac
+    case default
+       loc_bio_red_RDOMfrac = par_bio_red_RDOMfrac
+    end SELECT
+
+    ! *** ADJUST FOR TOTAL DOM + RDOM ******************************************************************************************** !
+    ! check for total DOM fraction exceeding 1.0 and re-scale (proportionally and to sum to 1.0)
+    loc_bio_red_DOMtotal = loc_bio_red_DOMfrac + loc_bio_red_RDOMfrac
+    if (loc_bio_red_DOMtotal > 1.0) then
+       loc_bio_red_DOMfrac = loc_bio_red_DOMfrac/loc_bio_red_DOMtotal
+       loc_bio_red_RDOMfrac = 1.0 - loc_bio_red_DOMfrac
+       loc_bio_red_DOMtotal = 1.0
+    end if
+
     ! *** CALCULATE PO4 DEPLETION ***
     ! NOTE: production is calculated as the concentration of newly-formed particulate material in the surface ocean layer
     !       that occurs within any single time step
@@ -896,41 +931,6 @@ CONTAINS
        end if
     end select
     ! ############################################################################################################################ !
-
-    ! *** SET DOM FRACTION ******************************************************************************************************* !
-    SELECT CASE (par_bio_prodopt)
-    case (                        &
-         & 'bio_P',               &
-         & 'bio_PFe',             &
-         & 'bio_PFeSi'            &
-         & )
-!!!loc_bio_red_DOMfrac = (1.0 - 0.5/(par_bio_kT0*exp(loc_TC/par_bio_kT_eT)))*par_bio_red_DOMfrac
-       loc_bio_red_DOMfrac = par_bio_red_DOMfrac
-    case default
-       loc_bio_red_DOMfrac = par_bio_red_DOMfrac
-    end SELECT
-
-    ! *** SET RDOM FRACTION ****************************************************************************************************** !
-    SELECT CASE (par_bio_prodopt)
-    case (                        &
-         & 'bio_P',               &
-         & 'bio_PFe',             &
-         & 'bio_PFeSi'            &
-         & )
-!!!loc_bio_red_RDOMfrac = (1.0 - 0.5/(par_bio_kT0*exp(loc_TC/par_bio_kT_eT)))*par_bio_red_RDOMfrac
-       loc_bio_red_RDOMfrac = par_bio_red_RDOMfrac
-    case default
-       loc_bio_red_RDOMfrac = par_bio_red_RDOMfrac
-    end SELECT
-
-    ! *** ADJUST FOR TOTAL DOM + RDOM ******************************************************************************************** !
-    ! check for total DOM fraction exceeding 1.0 and re-scale (proportionally and to sum to 1.0)
-    loc_bio_red_DOMtotal = loc_bio_red_DOMfrac + loc_bio_red_RDOMfrac
-    if (loc_bio_red_DOMtotal > 1.0) then
-       loc_bio_red_DOMfrac = loc_bio_red_DOMfrac/loc_bio_red_DOMtotal
-       loc_bio_red_RDOMfrac = 1.0 - loc_bio_red_DOMfrac
-       loc_bio_red_DOMtotal = 1.0
-    end if
 
     ! *** ADJUST PARTICULATE COMPOSITION 'REDFIELD' RATIOS *********************************************************************** !
     !


### PR DESCRIPTION
Fix to make EXAMPLE.worjh2.PO4.FPOC work, which used an initialised but zero value for the DOM fraction in the biological production scheme. Hence moving where the DOM fraction is calculated BEFORE it is used ... :o)