### PR TITLE
added parameters to control S,T limits of empirical constants

### DIFF
--- a/genie-biogem/src/fortran/biogem_box.f90
+++ b/genie-biogem/src/fortran/biogem_box.f90
@@ -9,6 +9,7 @@ MODULE biogem_box
 
 
   use gem_carbchem
+  use gem_geochem
   USE biogem_lib
   IMPLICIT NONE
   SAVE
@@ -91,10 +92,14 @@ CONTAINS
     ! set local variables
     ! temperature powers
     ! NOTE: temeprature must be converted to the correct units (degrees C)
-    ! NOTE: valid temperature range is 0 - 30 C for the Schmidt number empirical fit - see: Wanninkhof et al. [1992]
-    loc_TC  = ocn(io_T,dum_i,dum_j,n_k) - const_zeroC
-    if (loc_TC <  0.0) loc_TC =  0.0
-    if (loc_TC > 30.0) loc_TC = 30.0
+    ! NOTE: original valid temperature range was 0 - 30 C for the Schmidt number empirical fit - see: Wanninkhof et al. [1992]
+    if (ocn(io_T,dum_i,dum_j,n_k) <  (const_zeroC +  par_geochem_Tmin))  then
+       loc_TC = par_geochem_Tmin
+    elseif (ocn(io_T,dum_i,dum_j,n_k) > (const_zeroC + par_geochem_Tmax)) then
+       loc_TC = par_geochem_Tmax
+    else
+       loc_TC = ocn(io_T,dum_i,dum_j,n_k) - const_zeroC
+    endif
     loc_TC2 = loc_TC*loc_TC
     loc_TC3 = loc_TC2*loc_TC
     ! wind speed^2

--- a/genie-main/src/fortran/cmngem/gem_cmn.f90
+++ b/genie-main/src/fortran/cmngem/gem_cmn.f90
@@ -37,9 +37,7 @@ MODULE gem_cmn
   LOGICAL,DIMENSION(n_ocn)::ocn_select                                  !
   LOGICAL,DIMENSION(n_sed)::sed_select                                  !
   NAMELIST /ini_gem_nml/atm_select,ocn_select,sed_select
-  ! ------------------- MISC CONTROLS -------------------------------------------------------------------------------------------- !
-  real::par_grid_lon_offset                                             ! assumed lon grid offset (w.r.t. Prime Meridian)
-  NAMELIST /ini_gem_nml/par_grid_lon_offset
+  ! ------------------- GEOCHEM CONTROLS ----------------------------------------------------------------------------------------- !
   CHARACTER(len=63)::par_carbconstset_name                              ! carbonate dissociation constants set
   NAMELIST /ini_gem_nml/par_carbconstset_name
   real::par_carbchem_pH_tolerance                                       ! pH solution tolerance
@@ -47,6 +45,21 @@ MODULE gem_cmn
   NAMELIST /ini_gem_nml/par_carbchem_pH_tolerance,par_carbchem_pH_iterationmax
   logical::ctrl_carbchem_fail                                           ! Exit upon pH solution failure?
   NAMELIST /ini_gem_nml/ctrl_carbchem_fail
+  real::par_geochem_Tmin                                                ! minimum T used in empirical geochem calculations
+  real::par_geochem_Tmax                                                ! maximum T used in empirical geochem calculations
+  NAMELIST /ini_gem_nml/par_geochem_Tmin,par_geochem_Tmax
+  real::par_geochem_Smin                                                ! minimum S used in empirical geochem calculations
+  real::par_geochem_Smax                                                ! maximum S used in empirical geochem calculations
+  NAMELIST /ini_gem_nml/par_geochem_Smin,par_geochem_Smax
+  real::par_carbchem_Tmin                                                ! minimum T used in empirical carbchem calculations
+  real::par_carbchem_Tmax                                                ! maximum T used in empirical carbchem calculations
+  NAMELIST /ini_gem_nml/par_carbchem_Tmin,par_carbchem_Tmax
+  real::par_carbchem_Smin                                                ! minimum S used in empirical carbchem calculations
+  real::par_carbchem_Smax                                                ! maximum S used in empirical carbchem calculations
+  NAMELIST /ini_gem_nml/par_carbchem_Smin,par_carbchem_Smax
+  ! ------------------- MISC CONTROLS -------------------------------------------------------------------------------------------- !
+  real::par_grid_lon_offset                                             ! assumed lon grid offset (w.r.t. Prime Meridian)
+  NAMELIST /ini_gem_nml/par_grid_lon_offset
   integer::ctrl_debug_init,ctrl_debug_loop,ctrl_debug_end               ! 
   NAMELIST /ini_gem_nml/ctrl_debug_init,ctrl_debug_loop,ctrl_debug_end
   ! ------------------- I/O: DIRECTORY DEFINITIONS ------------------------------------------------------------------------------- !

--- a/genie-main/src/fortran/cmngem/gem_data.f90
+++ b/genie-main/src/fortran/cmngem/gem_data.f90
@@ -41,12 +41,17 @@ if (ctrl_debug_init > 0) then
     ! --- TRACER SELECTION  ------------------------------------------------------------------------------------------------------ !
     ! NOTE: reported at end of initialise_gem when tracer name information is available
     ! --- MISC CONTROLS  --------------------------------------------------------------------------------------------------------- !
-    print*,'--- MISC CONTROLS ---'
-    print*,'assumed longitudinal offset of the grid             : ',par_grid_lon_offset
+    print*,'--- GEOCHEM CONTROLS ---'
     print*,'carbonate dissociation constants set                : ',trim(par_carbconstset_name)
     print*,'pH solution tolerance                               : ',par_carbchem_pH_tolerance
     print*,'pH solution maximum number of iterations            : ',par_carbchem_pH_iterationmax
     print*,'Exit upon pH solution failure?                      : ',ctrl_carbchem_fail
+    print*,'minimum T used in empirical geochem calculations    : ',par_geochem_Tmin 
+    print*,'maximum T used in empirical geochem calculations    : ',par_geochem_Tmax
+    print*,'minimum S used in empirical geochem calculations    : ',par_geochem_Smin 
+    print*,'maximum S used in empirical geochem calculations    : ',par_geochem_Smax 
+    print*,'--- MISC CONTROLS ---'
+    print*,'assumed longitudinal offset of the grid             : ',par_grid_lon_offset
     print*,'Debug (initialization) level                        : ',ctrl_debug_init
     print*,'Debug (loop) level                                  : ',ctrl_debug_loop
     print*,'Debug (end) level                                   : ',ctrl_debug_end

--- a/genie-main/src/fortran/cmngem/gem_data.f90
+++ b/genie-main/src/fortran/cmngem/gem_data.f90
@@ -50,6 +50,10 @@ if (ctrl_debug_init > 0) then
     print*,'maximum T used in empirical geochem calculations    : ',par_geochem_Tmax
     print*,'minimum S used in empirical geochem calculations    : ',par_geochem_Smin 
     print*,'maximum S used in empirical geochem calculations    : ',par_geochem_Smax 
+    print*,'minimum T used in empirical carbchem calculations   : ',par_carbchem_Tmin 
+    print*,'maximum T used in empirical carbchem calculations   : ',par_carbchem_Tmax
+    print*,'minimum S used in empirical carbchem calculations   : ',par_carbchem_Smin 
+    print*,'maximum S used in empirical carbchem calculations   : ',par_carbchem_Smax 
     print*,'--- MISC CONTROLS ---'
     print*,'assumed longitudinal offset of the grid             : ',par_grid_lon_offset
     print*,'Debug (initialization) level                        : ',ctrl_debug_init

--- a/genie-main/src/fortran/cmngem/gem_geochem.f90
+++ b/genie-main/src/fortran/cmngem/gem_geochem.f90
@@ -13,16 +13,75 @@ MODULE gem_geochem
   SAVE
 
 
-  ! ****************************************************************************************************************************** !
-  ! ****************************************************************************************************************************** !
-
-
 CONTAINS
 
 
-
+  ! ****************************************************************************************************************************** !
+  ! CALCULATE SOLUBILITY COEFFICIENT
+  function fun_calc_solconst(dum_ia,dum_T,dum_S,dum_rho)
+    ! result variable
+    REAL::fun_calc_solconst
+    ! dummy arguments
+    integer,INTENT(in)::dum_ia
+    real,INTENT(in)::dum_T,dum_S,dum_rho
+    ! local variables
+    REAL::loc_T,loc_rT,loc_Tr100,loc_S
+    ! calculate local constants
+    ! NOTE: pressure in units of (bar) (1 m depth approx = 1 dbar pressure)
+    ! NOTE: temperature in K
+    ! NOTE: restrict valid T,S range for empirical fit
+    ! NOTE: original default was the same as for Mehrbach K1, K2 CONSTANTS:
+    !       2.0  <= T <= 35 C
+    !       26.0 <= S <= 43 PSU
+    ! NOTE: hence carbchem_*, rather than geochem_* parameter set (logically: geochem_* as per air-sea gas exchange ...)
+    if (dum_T <  (const_zeroC +  par_carbchem_Tmin))  then
+       loc_T = const_zeroC +  par_carbchem_Tmin
+    elseif (dum_T > (const_zeroC + par_carbchem_Tmax)) then
+       loc_T = const_zeroC + par_carbchem_Tmax
+    else
+       loc_T = dum_T
+    endif
+    if (dum_S < par_carbchem_Smin) then
+       loc_S = par_carbchem_Smin
+    elseif (dum_S > par_carbchem_Smax) then
+       loc_S = par_carbchem_Smax
+    else
+       loc_S = dum_S
+    endif
+    ! set local constants
+    loc_rT    = 1.0/loc_T
+    loc_Tr100 = loc_T/100.0
+    ! calculate Solubility Coefficients (mol/(kg atm)) and return function value
+    ! NOTE: for CO2 and N2O, the soluability coefficient is in units of mol/(kg atm)
+    !       rather than as a Bunsen Solubility Coefficient (see Wanninkohf [1992])
+    !       => convert units for others
+    ! NOTE: for CFC-11 and CFC-12, the soluability coefficient is in units of mol/(kg atm)
+    !       rather than as a Bunsen Solubility Coefficient (see Wanninkohf [1992])
+    !       (actaully, it is not really this simple and K should be corrected for water vapour pressure and lame things like that)
+    SELECT CASE (dum_ia)
+    CASE (ia_pCO2,ia_pN2O)
+       fun_calc_solconst = EXP( &
+            & par_bunsen_coef(1,dum_ia) + par_bunsen_coef(2,dum_ia)*(100*loc_rT) + par_bunsen_coef(3,dum_ia)*LOG(loc_Tr100) + &
+            & loc_S* &
+            & (par_bunsen_coef(4,dum_ia) + par_bunsen_coef(5,dum_ia)*(loc_Tr100) + par_bunsen_coef(6,dum_ia)*(loc_Tr100)**2) &
+            &  )
+    CASE (ia_pCFC11,ia_pCFC12)
+       fun_calc_solconst = EXP( &
+            & par_bunsen_coef(1,dum_ia) + par_bunsen_coef(2,dum_ia)*(100*loc_rT) + par_bunsen_coef(3,dum_ia)*LOG(loc_Tr100) + &
+            & loc_S* &
+            & (par_bunsen_coef(4,dum_ia) + par_bunsen_coef(5,dum_ia)*(loc_Tr100) + par_bunsen_coef(6,dum_ia)*(loc_Tr100)**2) &
+            &  )
+    CASE default
+       fun_calc_solconst = EXP( &
+            & par_bunsen_coef(1,dum_ia) + par_bunsen_coef(2,dum_ia)*(100*loc_rT) + par_bunsen_coef(3,dum_ia)*LOG(loc_Tr100) + &
+            & loc_S* &
+            & (par_bunsen_coef(4,dum_ia) + par_bunsen_coef(5,dum_ia)*(loc_Tr100) + par_bunsen_coef(6,dum_ia)*(loc_Tr100)**2) &
+            &  )/ &
+            & (dum_rho*const_V)
+    END SELECT
+  end function fun_calc_solconst
+  ! ****************************************************************************************************************************** !
 
 
 END MODULE gem_geochem
-
 

--- a/genie-main/src/xml-config/xml/definition.xml
+++ b/genie-main/src/xml-config/xml/definition.xml
@@ -1214,11 +1214,7 @@
                             <description></description>
                         </param>
                   </paramArray>
-<!-- MISC CONTROLS  -->
-                    <param name="par_grid_lon_offset">
-                        <value datatype="real">-260.0</value>
-                        <description>assumed longitudinal offset of the grid</description>
-                    </param>
+<!-- GEOCHEM CONTROLS  -->
                     <param name="par_carbconstset_name">
                         <value datatype="string">Mehrbach</value>
                         <description>carbonate dissociation constants set</description>
@@ -1234,6 +1230,43 @@
                     <param name="ctrl_carbchem_fail">
                         <value datatype="boolean">.true.</value>
                         <description>exit upon pH solution failure?</description>
+                    </param>
+                    <param name="par_geochem_Tmin">
+                        <value datatype="real">0.0</value>
+                        <description>minimum T used in empirical geochem calculations [default: 0 - 30 C for the Schmidt number empirical fit - see: Wanninkhof et al. [1992]]</description>
+                    </param>
+                    <param name="par_geochem_Tmax">
+                        <value datatype="real">30.0</value>
+                        <description>maximum T used in empirical geochem calculations [default: 0 - 30 C for the Schmidt number empirical fit - see: Wanninkhof et al. [1992]]</description>
+                    </param>
+                    <param name="par_geochem_Smin">
+                        <value datatype="real">26.0</value>
+                        <description>minimum S used in empirical geochem calculations [not (yet) used -- set as per par_carbchem_Smin]</description>
+                    </param>
+                    <param name="par_geochem_Smax">
+                        <value datatype="real">43.0</value>
+                        <description>maximum S used in empirical geochem calculations [not (yet) used -- set as per par_carbchem_Smax]</description>
+                    </param>
+                    <param name="par_carbchem_Tmin">
+                        <value datatype="real">2.0</value>
+                        <description>minimum T used in empirical carbchem calculations [default from Mehrbach: 2.0 lte T lte 35 C]</description>
+                    </param>
+                    <param name="par_carbchem_Tmax">
+                        <value datatype="real">35.0</value>
+                        <description>maximum T used in empirical carbchem calculations [default from Mehrbach: 2.0 lte T lte 35 C]</description>
+                    </param>
+                    <param name="par_carbchem_Smin">
+                        <value datatype="real">26.0</value>
+                        <description>minimum S used in empirical carbchem calculations [default from Mehrbach: 26.0 lte S lte 43 PSU]</description>
+                    </param>
+                    <param name="par_carbchem_Smax">
+                        <value datatype="real">43.0</value>
+                        <description>maximum S used in empirical carbchem calculations [default from Mehrbach: 26.0 lte S lte 43 PSU]</description>
+                    </param>
+<!-- MISC CONTROLS  -->
+                    <param name="par_grid_lon_offset">
+                        <value datatype="real">-260.0</value>
+                        <description>assumed longitudinal offset of the grid</description>
                     </param>
                     <param name="ctrl_debug_init">
                         <value datatype="integer">0</value>


### PR DESCRIPTION
changes to:
(0) move gas solubility calculation into geochem rather than carbchem module (tidying up)
(1) allow the T and S limits of the empirical carbonate chemistry constants to be set (as opposed to the original fixed options depending on which constant set was selected)
(2) allow the T and S limits of gas solubility to be set
(3) allow the T limits of the gas transfer velocity to be set
(1) and (2) are set by the par_carbchem_* limits, and (3) by the par_geochem_* limits
Defaults are as per the original code and make testbiogem passes.