### PR TITLE
New SEDGEM detrital flux behaviour option

### DIFF
--- a/genie-main/src/xml-config/xml/definition.xml
+++ b/genie-main/src/xml-config/xml/definition.xml
@@ -6476,6 +6476,15 @@
 			<value datatype="integer">1</value>
                         <description># sedimentary stack sub-layers to drop off bottom</description>
                     </param>
+<!-- DETRITAL CONFIGURATION  -->
+                    <param name="par_sed_fdet">
+			<value datatype="real">0.150</value>
+                        <description>prescribed (additional) flux of detrital material to the seds (g cm-2 kyr-1)</description>
+                    </param>
+                    <param name="ctrl_sed_det_NOdust">
+			<value datatype="boolean">.false.</value>
+                        <description>No pelagic (dust) detrital contribution?</description>
+                    </param>
 <!-- DIAGENESIS SCHEME: SELECTION  -->
                     <param name="par_sed_diagen_CaCO3opt">
 			<value datatype="string">archer1991explicit</value>
@@ -6509,10 +6518,6 @@
                     <param name="par_sed_mix_k_sur_min">
 			<value datatype="real">0.0001</value>
                         <description>maximum surface bioturbation mixing rate (cm2 yr-1)</description>
-                    </param>
-                    <param name="par_sed_fdet">
-			<value datatype="real">0.150</value>
-                        <description>prescribed (additional) flux of detrital material to the seds (g cm-2 kyr-1)</description>
                     </param>
                     <param name="ctrl_sed_noerosion">
 			<value datatype="boolean">.false.</value>

--- a/genie-sedgem/src/fortran/sedgem.f90
+++ b/genie-sedgem/src/fortran/sedgem.f90
@@ -190,6 +190,10 @@ SUBROUTINE sedgem(          &
            !       ... but allow prescribed (uniform) sed det flux PLUS spatial burial flux
            ! NOTE: if an opal flux is provided but opal is not selected as a tracer, add to the detrital field
            if (sed_select(is_det)) then
+              if (ctrl_sed_det_NOdust) then
+                 ! zero det flux, which at this point is assumed to be all pelagic (dust)
+                 dum_sfxsumsed(is_det,i,j) = 0.0
+              endif
               if (ctrl_sed_Fdet) then
                  dum_sfxsumsed(is_det,i,j) =  &
                       & conv_m2_cm2*conv_det_g_mol*(conv_yr_kyr*loc_dtyr)*par_sed_fdet + &

--- a/genie-sedgem/src/fortran/sedgem_data.f90
+++ b/genie-sedgem/src/fortran/sedgem_data.f90
@@ -70,6 +70,9 @@ CONTAINS
        print*,'# sedimentary stack sub-layers                      : ',n_sed_tot
        print*,'# initial sedimentary stack sub-layers filled       : ',n_sed_tot_init
        print*,'# sedimentary stack sub-layers to drop off bottom   : ',n_sed_tot_drop
+       ! --- DETRITAL CONFIGURATION ---------------------------------------------------------------------------------------------- !
+       print*,'Flux of refractory material (g cm-2 kyr-1)          : ',par_sed_fdet
+       print*,'No pelagic (dust) detrital contribution?            : ',ctrl_sed_det_NOdust
        ! --- DIAGENESIS SCHEME: SELECTION ---------------------------------------------------------------------------------------- !
        print*,'--- DIAGENESIS SCHEME: SELECTION -------------------'
        print*,'CaCO3 diagenesis scheme                             : ',par_sed_diagen_CaCO3opt
@@ -82,7 +85,6 @@ CONTAINS
        print*,'maximum layer depth for bioturbation                : ',par_n_sed_mix
        print*,'Max surface bioturbation mixing rate (cm2 yr-1)     : ',par_sed_mix_k_sur_max
        print*,'Min surface bioturbation mixing rate (cm2 yr-1)     : ',par_sed_mix_k_sur_min
-       print*,'Flux of refractory material (g cm-2 kyr-1)          : ',par_sed_fdet
        print*,'Prevent CaCO3 erosion (Fdis > Fsed)?                : ',ctrl_sed_noerosion
        print*,'CaCO3 interface dissolution?                        : ',ctrl_sed_interface
        print*,'CaCO3 red tracer tag fraction                       : ',par_sed_CaCO3_fred

--- a/genie-sedgem/src/fortran/sedgem_lib.f90
+++ b/genie-sedgem/src/fortran/sedgem_lib.f90
@@ -44,6 +44,11 @@ MODULE sedgem_lib
   integer::n_sed_tot_init                                        ! # initial sedimentary stack sub-layers filled
   integer::n_sed_tot_drop                                        ! # sedimentary stack sub-layers to drop off bottom     
   NAMELIST /ini_sedgem_nml/n_sed_tot,n_sed_tot_init,n_sed_tot_drop
+  ! ------------------- DETRITAL CONFIGURATION ----------------------------------------------------------------------------------- !
+  REAL::par_sed_fdet                                             ! prescribed (additional) flux of detrital material to the seds
+  NAMELIST /ini_sedgem_nml/par_sed_fdet
+  LOGICAL::ctrl_sed_det_NOdust                                   ! no pelagic (dust) detrital contribution?
+  NAMELIST /ini_sedgem_nml/ctrl_sed_det_NOdust
   ! ------------------- DIAGENESIS SCHEME: SELECTION ----------------------------------------------------------------------------- !
   character(len=63)::par_sed_diagen_CaCO3opt                     ! CaCO3 diagenesis scheme
   character(len=63)::par_sed_diagen_opalopt                      ! opal diagenesis scheme
@@ -58,8 +63,6 @@ MODULE sedgem_lib
   REAL::par_sed_mix_k_sur_max                                    ! maximum surface bioturbation mixing rate (cm2 yr-1)
   REAL::par_sed_mix_k_sur_min                                    ! minimum surface bioturbation mixing rate (cm2 yr-1)
   NAMELIST /ini_sedgem_nml/par_sed_mix_k_sur_max,par_sed_mix_k_sur_min
-  REAL::par_sed_fdet                                             ! prescribed (additional) flux of detrital material to the seds
-  NAMELIST /ini_sedgem_nml/par_sed_fdet
   logical::ctrl_sed_noerosion
   NAMELIST /ini_sedgem_nml/ctrl_sed_noerosion
   logical::ctrl_sed_interface                                    ! CaCO3 interface dissolution?
@@ -86,14 +89,15 @@ MODULE sedgem_lib
   NAMELIST /ini_sedgem_nml/par_sed_diagen_fracC2Ppres_ox,par_sed_diagen_fracC2Ppres_anox,par_sed_diagen_fracC2Ppres_eux
   LOGICAL::ctrl_sed_huelse2017_remin_POP                         ! Force return of PO4 to ocean in HUELSE 2017 scheme
   NAMELIST /ini_sedgem_nml/ctrl_sed_huelse2017_remin_POP  
-  ! ------------------- DIAGENESIS SCHEME: ORGANIC MATTER HUELSE 2017 ------------------------------------------------------------------------ !
+  ! ------------------- DIAGENESIS SCHEME: ORGANIC MATTER HUELSE 2017 ------------------------------------------------------------ !
   character(len=63)::par_sed_huelse2017_kscheme                  ! Corg k parametrisation scheme ID string
   NAMELIST /ini_sedgem_nml/par_sed_huelse2017_kscheme
   logical::par_sed_huelse2017_redox                              ! Corg degradation rates redox dependent?
   logical::par_sed_huelse2017_P_cycle                            ! Include explicit P-cycle in OMEN-SED?
+  NAMELIST /ini_sedgem_nml/par_sed_huelse2017_redox,par_sed_huelse2017_P_cycle
   logical::par_sed_huelse2017_remove_impl_sulALK                 ! Remove implicit Alk associated with buried sulf-OM? / no permanent ALk gain?
   logical::par_sed_huelse2017_sim_P_loss                         ! Simulate ocean Porg loss with buried sulf-OM?
-  NAMELIST /ini_sedgem_nml/par_sed_huelse2017_redox,par_sed_huelse2017_P_cycle,par_sed_huelse2017_remove_impl_sulALK,par_sed_huelse2017_sim_P_loss
+  NAMELIST /ini_sedgem_nml/par_sed_huelse2017_remove_impl_sulALK,par_sed_huelse2017_sim_P_loss
   REAL::par_sed_huelse2017_k1                                    ! labile degradation rate constant, units of 1/yr
   REAL::par_sed_huelse2017_k2                                    ! refractory degradation rate constant, units of 1/yr
   REAL::par_sed_huelse2017_k2_order                              ! k2 = k1/par_sed_huelse2017_k2_order
@@ -108,7 +112,7 @@ MODULE sedgem_lib
   integer::par_sed_archer1991_iterationmax                       ! loop limit in 'o2org' subroutine
   NAMELIST /ini_sedgem_nml/par_sed_archer1991_iterationmax
   NAMELIST /ini_sedgem_nml/par_sed_archer1991_iterationmax
-       ! --- DIAGENESIS SCHEME: opal --------------------------------------------------------------------------------------------- !
+  ! ------------------- DIAGENESIS SCHEME: opal ---------------------------------------------------------------------------------- !
   REAL::par_sed_opal_KSi0                                        ! base opal KSi value (yr-1)
   NAMELIST /ini_sedgem_nml/par_sed_opal_KSi0
   ! ------------------- CaCO3 PRODUCTION ----------------------------------------------------------------------------------------- !


### PR DESCRIPTION
Added option for not including pelagic detrital (dust) in the sediment detrital burial flux.
Tested with and without the option, which is set to false by default.
No other implications or anticipated knock-on effects.