### PR TITLE
added option to add blue flux forcing to the salinity flux forcing field

### DIFF
--- a/genie-biogem/src/fortran/biogem.f90
+++ b/genie-biogem/src/fortran/biogem.f90
@@ -815,6 +815,15 @@ subroutine biogem(        &
                     END DO
                  END IF
               END DO
+              ! test for, and apply, additional salinity flux forcing
+              if (.NOT. ctrl_force_ocn_age) then
+                 IF (force_flux_ocn_select(io_S) .AND. force_flux_ocn_select(io_colb)) THEN
+                    DO k=loc_k1,n_k
+                       locijk_focn(io_S,i,j,k)    = locijk_focn(io_S,i,j,k) + locijk_focn(io_colb,i,j,k)
+                       locijk_focn(io_colb,i,j,k) = 0.0
+                    END DO
+                 end if
+              end if
               ! SEDIMENT TRACERS #1
               ! NOTE: currently, fluxes are valid at the ocean surface only
               ! NOTE: addition is made directly to particulate sedimentary tracer array (scaled by time-step and cell mass)


### PR DESCRIPTION
Added the option of using the blue tracer as an additional salinity flux forcing field, where, for example, one might have a generic regional flux forcing to maintain an AMOC, but want a time-varying separate flux to screw with it (aka, perturb individual convicting regions).
I have tested that a combined flux forcing does work, and that make testbiogem passes.
Basically -- if you are not using ocean age tracers, requiring both r and b color tracers, then selecting both salinity and b color flux forcings enables the flux combining.
TO-DO: check out and repeat make testbiogem, and simply visually check over the code for any issue.