### PR TITLE
_DEV --> master

### DIFF
--- a/genie-biogem/src/fortran/biogem.f90
+++ b/genie-biogem/src/fortran/biogem.f90
@@ -3189,8 +3189,10 @@ SUBROUTINE diag_biogem_timeseries( &
   REAL,DIMENSION(n_ocn,n_i,n_j)::locij_fsedocn                   ! local sed->ocean change (ocn tracer currency) (mol)
   REAL,DIMENSION(n_ocn,n_i,n_j)::locij_ocn_ben                   ! local benthic ocean composition
   REAL,DIMENSION(n_i,n_j)::locij_mask_ben                        ! benthic save mask
-  real::loc_ocn_tot_M,loc_ocn_tot_A,loc_ocnatm_tot_A             !
-  real::loc_ocn_rtot_M,loc_ocn_rtot_A,loc_ocnatm_rtot_A          !
+  real::loc_ocn_tot_M                                            !
+  real::loc_ocn_rtot_M                                           !
+  real::loc_ocn_tot_A,loc_opn_tot_A,loc_ocnatm_tot_A             !
+  real::loc_ocn_rtot_A,loc_opn_rtot_A,loc_ocnatm_rtot_A          !
   real::loc_ocnsed_tot_A,loc_ocnsed_tot_A_ben                    !
   real::loc_ocnsed_rtot_A,loc_ocnsed_rtot_A_ben                  !
   real::loc_tot_A                                                !
@@ -3247,6 +3249,13 @@ SUBROUTINE diag_biogem_timeseries( &
               loc_ocn_rtot_A = 1.0/loc_ocn_tot_A
            else
               loc_ocn_rtot_A = 0.0
+           end if
+           ! total open ocean surface area (ice-free)
+           loc_opn_tot_A = sum((1.0 - phys_ocnatm(ipoa_seaice,:,:))*phys_ocn(ipo_A,:,:,n_k))
+           if (loc_opn_tot_A > const_real_nullsmall) then
+              loc_opn_rtot_A = 1.0/loc_opn_tot_A
+           else
+              loc_opn_rtot_A = 0.0
            end if
            ! total ocean-sediment interface area
            loc_ocnsed_tot_A = sum(phys_ocn(ipo_A,:,:,n_k))
@@ -3373,6 +3382,8 @@ SUBROUTINE diag_biogem_timeseries( &
                  io = conv_iselected_io(l)
                  int_ocn_sur_sig(io) = int_ocn_sur_sig(io) + loc_dtyr*&
                       & SUM(phys_ocn(ipo_A,:,:,n_k)*ocn(io,:,:,n_k))*loc_ocn_rtot_A
+                 int_ocn_opn_sig(io) = int_ocn_opn_sig(io) + loc_dtyr*&
+                      & SUM((1.0 - phys_ocnatm(ipoa_seaice,:,:))*phys_ocn(ipo_A,:,:,n_k)*ocn(io,:,:,n_k))*loc_opn_rtot_A
               END DO
               IF (ctrl_force_ocn_age) THEN
                  DO i=1,n_i
@@ -3392,6 +3403,8 @@ SUBROUTINE diag_biogem_timeseries( &
               DO ic=1,n_carb
                  int_carb_sur_sig(ic) = int_carb_sur_sig(ic) + loc_dtyr*&
                       & SUM(phys_ocn(ipo_A,:,:,n_k)*carb(ic,:,:,n_k))*loc_ocn_rtot_A
+                 int_carb_opn_sig(ic) = int_carb_opn_sig(ic) + loc_dtyr*&
+                      & SUM((1.0 - phys_ocnatm(ipoa_seaice,:,:))*phys_ocn(ipo_A,:,:,n_k)*carb(ic,:,:,n_k))*loc_opn_rtot_A
               END DO
            end if
            IF (ctrl_data_save_sig_ocn_sur) THEN
@@ -3458,8 +3471,12 @@ SUBROUTINE diag_biogem_timeseries( &
               ! (1) mean global properties
               int_misc_ocn_solfor_sig = int_misc_ocn_solfor_sig + &
                    & loc_dtyr*loc_ocn_rtot_A*sum(phys_ocn(ipo_A,:,:,n_k)*phys_ocnatm(ipoa_solfor,:,:))
+              int_misc_opn_solfor_sig = int_misc_opn_solfor_sig + &
+                   & loc_dtyr*loc_opn_rtot_A*sum(phys_ocn(ipo_A,:,:,n_k)*phys_ocnatm(ipoa_solfor,:,:))
               int_misc_ocn_fxsw_sig = int_misc_ocn_fxsw_sig + &
                    & loc_dtyr*loc_ocn_rtot_A*sum(phys_ocn(ipo_A,:,:,n_k)*phys_ocnatm(ipoa_fxsw,:,:))
+              int_misc_opn_fxsw_sig = int_misc_opn_fxsw_sig + &
+                   & loc_dtyr*loc_opn_rtot_A*sum(phys_ocn(ipo_A,:,:,n_k)*phys_ocnatm(ipoa_fxsw,:,:))
               ! (2) latitudinal/seasonal properties
               !     NOTE: done very crudely and taking values from a single specified time-step of the averaging only
               if (int_t_sig_count == par_t_sig_count_N) then

--- a/genie-biogem/src/fortran/biogem_data.f90
+++ b/genie-biogem/src/fortran/biogem_data.f90
@@ -1329,8 +1329,10 @@ CONTAINS
     int_focnsed_sig(:)      = 0.0
     int_fsedocn_sig(:)      = 0.0
     int_ocn_sur_sig(:)      = 0.0
+    int_ocn_opn_sig(:)      = 0.0
     int_ocn_ben_sig(:)      = 0.0
     int_carb_sur_sig(:)     = 0.0
+    int_carb_opn_sig(:)     = 0.0
     int_carb_ben_sig(:)     = 0.0
     int_misc_age_sig        = 0.0
     int_misc_age_sur_sig    = 0.0
@@ -1346,7 +1348,9 @@ CONTAINS
     int_misc_det_Fe_tot_sig = 0.0
     int_misc_det_Fe_dis_sig = 0.0
     int_misc_ocn_solfor_sig = 0.0
+    int_misc_opn_solfor_sig = 0.0
     int_misc_ocn_fxsw_sig   = 0.0
+    int_misc_opn_fxsw_sig   = 0.0
     int_ocnsed_sig(:)       = 0.0
     int_diag_bio_sig(:)     = 0.0
     int_diag_geochem_sig(:) = 0.0

--- a/genie-biogem/src/fortran/biogem_data_ascii.f90
+++ b/genie-biogem/src/fortran/biogem_data_ascii.f90
@@ -40,16 +40,24 @@ CONTAINS
           IF (ctrl_data_save_sig_ocn_sur) THEN
              SELECT CASE (ocn_type(io))
              CASE (0)
-                If (io == io_T) loc_string = '% time (yr) / temperature (C) / _surT (C) / _benT (degrees C)'
-                If (io == io_S) loc_string = '% time (yr) / salinity (o/oo) / _surS (o/oo) / _benS (o/oo)'
+                If (io == io_T) loc_string = &
+                     & '% time (yr) / temperature (C) / _surT (ice-free) (C) / _benT (C) / _surT (C)'
+                If (io == io_S) loc_string = &
+                     & '% time (yr) / salinity (o/oo) / _surS (ice-free) (o/oo) / _benS (o/oo) / _surS (o/oo)'
              CASE (1)
-                loc_string = '% time (yr) / global ' //TRIM(string_ocn(io))//' (mol) / global ' // &
-                     & TRIM(string_ocn(io))//' (mol kg-1)'// &
-                     & ' / surface ' //TRIM(string_ocn(io))//' (mol kg-1) / benthic ' //TRIM(string_ocn(io))//' (mol kg-1)'
+                loc_string = '% time (yr) / ' //&
+                     & 'global total ' //TRIM(string_ocn(io))//' (mol) / ' //&
+                     & 'global mean ' //TRIM(string_ocn(io))//' (mol kg-1) / ' //&
+                     & 'surface (ice-free)' //TRIM(string_ocn(io))//' (mol kg-1) / ' //&
+                     & 'benthic ' //TRIM(string_ocn(io))//' (mol kg-1) / ' //&
+                     & 'surface' //TRIM(string_ocn(io))//' (mol kg-1)'
              CASE (n_itype_min:n_itype_max)
-                loc_string = '% time (yr) / global '//TRIM(string_ocn(io))//' (mol) / global ' // &
-                     & TRIM(string_ocn(io))//' (o/oo)'// &
-                     & ' / surface ' //TRIM(string_ocn(io))//' (o/oo) / benthic ' //TRIM(string_ocn(io))//' (o/oo)'
+                loc_string = '% time (yr) / ' //&
+                     & 'global total '//TRIM(string_ocn(io))//' (mol) / ' //&
+                     & 'global ' // TRIM(string_ocn(io))//' (o/oo) / ' //&
+                     & 'surface (ice-free) ' //TRIM(string_ocn(io))//' (o/oo) / ' //&
+                     & 'benthic ' //TRIM(string_ocn(io))//' (o/oo) / ' //&
+                     & 'surface ' //TRIM(string_ocn(io))//' (o/oo)'
              end SELECT
           else
              SELECT CASE (ocn_type(io))
@@ -57,10 +65,10 @@ CONTAINS
                 If (io == io_T) loc_string = '% time (yr) / temperature (degrees C)'
                 If (io == io_S) loc_string = '% time (yr) / salinity (o/oo)'
              CASE (1)
-                loc_string = '% time (yr) / global '//TRIM(string_ocn(io))//' (mol) / global ' // &
+                loc_string = '% time (yr) / global total '//TRIM(string_ocn(io))//' (mol) / global mean ' // &
                      & TRIM(string_ocn(io))//' (mol kg-1)'
              CASE (n_itype_min:n_itype_max)
-                loc_string = '% time (yr) / global '//TRIM(string_ocn(io))//' (mol) / global ' // &
+                loc_string = '% time (yr) / global total '//TRIM(string_ocn(io))//' (mol) / global ' // &
                      & TRIM(string_ocn(io))//' (o/oo)'
              end SELECT
           end IF
@@ -315,11 +323,16 @@ CONTAINS
              loc_string = '% time (yr) / mean saturation state'
           CASE (ic_conc_CO2,ic_conc_HCO3,ic_conc_CO3)
              if (ocn_select(io_DIC_14C)) then
-                loc_string = '% time (yr) / surface '//TRIM(string_carb(ic))//' (mol kg-1) / surface '//TRIM(string_carb(ic))// &
-                     & ' d13C (o/oo) / surface '//TRIM(string_carb(ic))//' d14C (o/oo)'
+                loc_string = '% time (yr) / ' //&
+                     & 'surface mean (ice-free) '//TRIM(string_carb(ic))//' (mol kg-1) / ' //&
+                     & 'surface '//TRIM(string_carb(ic))// ' d13C (o/oo) / ' //&
+                     & 'surface '//TRIM(string_carb(ic))//' d14C (o/oo) / ' //&
+                     & 'surface mean '//TRIM(string_carb(ic))//' (mol kg-1)' 
              elseif (ocn_select(io_DIC_13C)) then
-                loc_string = '% time (yr) / surface '//TRIM(string_carb(ic))//' (mol kg-1) / surface '//TRIM(string_carb(ic))// &
-                     & ' d13C (o/oo)'
+                loc_string = '% time (yr) / ' //&
+                     & 'surface mean (ice-free) '//TRIM(string_carb(ic))//' (mol kg-1) / ' //&
+                     & 'surface '//TRIM(string_carb(ic))// ' d13C (o/oo) / ' //&
+                     & 'surface mean '//TRIM(string_carb(ic))//' (mol kg-1)'
              else
                 loc_string = '% time (yr) / surface '//TRIM(string_carb(ic))//' (mol kg-1)'
              end if
@@ -978,9 +991,9 @@ CONTAINS
     REAL::loc_t
     real::loc_opsi_scale
     real::loc_ocn_tot_M,loc_ocn_tot_M_sur,loc_ocn_tot_A
-    real::loc_sig,loc_sig_sur,loc_sig_ben,loc_rsig
-    real::loc_tot,loc_tot_sur,loc_tot_ben
-    real::loc_frac,loc_frac_sur,loc_frac_ben,loc_standard
+    real::loc_sig,loc_sig_sur,loc_sig_opn,loc_sig_ben,loc_rsig
+    real::loc_tot,loc_tot_sur,loc_tot_opn,loc_tot_ben
+    real::loc_frac,loc_frac_sur,loc_frac_opn,loc_frac_ben,loc_standard
     real::loc_d13C,loc_d14C
     REAL,DIMENSION(n_k)::loc_sig_3D,loc_tot_3D,loc_frac_3D,loc_standard_3D 
     CHARACTER(len=255)::loc_filename
@@ -1021,19 +1034,22 @@ CONTAINS
              IF (ctrl_data_save_sig_ocn_sur .OR. (par_data_save_level > 3)) THEN
                 If (io == io_T) then
                    loc_sig_sur = int_ocn_sur_sig(io)/int_t_sig - const_zeroC
+                   loc_sig_opn = int_ocn_opn_sig(io)/int_t_sig - const_zeroC
                    loc_sig_ben = int_ocn_ben_sig(io)/int_t_sig - const_zeroC
                 else
                    loc_sig_sur = int_ocn_sur_sig(io)/int_t_sig
+                   loc_sig_opn = int_ocn_opn_sig(io)/int_t_sig
                    loc_sig_ben = int_ocn_ben_sig(io)/int_t_sig
                 end If
                 call check_unit(out,__LINE__,__FILE__)
                 OPEN(unit=out,file=loc_filename,action='write',status='old',position='append',iostat=ios)
                 call check_iostat(ios,__LINE__,__FILE__)
-                WRITE(unit=out,fmt='(f12.3,3f12.6)',iostat=ios) &
-                     & loc_t,                                  &
-                     & loc_sig,                                &
-                     & loc_sig_sur,                            &
-                     & loc_sig_ben
+                WRITE(unit=out,fmt='(f12.3,4f12.6)',iostat=ios) &
+                     & loc_t,                                   &
+                     & loc_sig,                                 &
+                     & loc_sig_sur,                             &
+                     & loc_sig_ben,                             &
+                     & loc_sig_opn
                 call check_iostat(ios,__LINE__,__FILE__)
                 CLOSE(unit=out,iostat=ios)
                 call check_iostat(ios,__LINE__,__FILE__)
@@ -1042,7 +1058,7 @@ CONTAINS
                 OPEN(unit=out,file=loc_filename,action='write',status='old',position='append',iostat=ios)
                 call check_iostat(ios,__LINE__,__FILE__)
                 WRITE(unit=out,fmt='(f12.3,f12.6)',iostat=ios) &
-                     & loc_t,                                 &
+                     & loc_t,                                  &
                      & loc_sig
                 call check_iostat(ios,__LINE__,__FILE__)
                 CLOSE(unit=out,iostat=ios)
@@ -1052,16 +1068,18 @@ CONTAINS
              loc_sig = int_ocn_sig(io)/int_t_sig
              IF (ctrl_data_save_sig_ocn_sur) THEN
                 loc_sig_sur = int_ocn_sur_sig(io)/int_t_sig
+                loc_sig_opn = int_ocn_opn_sig(io)/int_t_sig
                 loc_sig_ben = int_ocn_ben_sig(io)/int_t_sig
                 call check_unit(out,__LINE__,__FILE__)
                 OPEN(unit=out,file=loc_filename,action='write',status='old',position='append',iostat=ios)
                 call check_iostat(ios,__LINE__,__FILE__)
-                WRITE(unit=out,fmt='(f12.3,e20.12,3e14.6)',iostat=ios) &
-                     & loc_t,                                   &
-                     & loc_ocn_tot_M*loc_sig,                   &
-                     & loc_sig,                                 &
-                     & loc_sig_sur,                             &
-                     & loc_sig_ben
+                WRITE(unit=out,fmt='(f12.3,e20.12,4e14.6)',iostat=ios) &
+                     & loc_t,                                          &
+                     & loc_ocn_tot_M*loc_sig,                          &
+                     & loc_sig,                                        &
+                     & loc_sig_sur,                                    &
+                     & loc_sig_ben,                                    &
+                     & loc_sig_opn
                 call check_iostat(ios,__LINE__,__FILE__)
                 CLOSE(unit=out,iostat=ios)
                 call check_iostat(ios,__LINE__,__FILE__)                
@@ -1087,18 +1105,22 @@ CONTAINS
                 loc_tot_sur    = int_ocn_sur_sig(ocn_dep(io))/int_t_sig
                 loc_frac_sur   = int_ocn_sur_sig(io)/int_t_sig
                 loc_sig_sur    = fun_calc_isotope_delta(loc_tot_sur,loc_frac_sur,loc_standard,.FALSE.,const_nulliso)
+                loc_tot_opn    = int_ocn_opn_sig(ocn_dep(io))/int_t_sig
+                loc_frac_opn   = int_ocn_opn_sig(io)/int_t_sig
+                loc_sig_opn    = fun_calc_isotope_delta(loc_tot_opn,loc_frac_opn,loc_standard,.FALSE.,const_nulliso)
                 loc_tot_ben    = int_ocn_ben_sig(ocn_dep(io))/int_t_sig
                 loc_frac_ben   = int_ocn_ben_sig(io)/int_t_sig
                 loc_sig_ben    = fun_calc_isotope_delta(loc_tot_ben,loc_frac_ben,loc_standard,.FALSE.,const_nulliso)
                 call check_unit(out,__LINE__,__FILE__)
                 OPEN(unit=out,file=loc_filename,action='write',status='old',position='append',iostat=ios)
                 call check_iostat(ios,__LINE__,__FILE__)
-                WRITE(unit=out,fmt='(f12.3,e20.12,3f12.3)',iostat=ios) &
-                     & loc_t,                                         &
-                     & loc_ocn_tot_M*loc_frac,                        &
-                     & loc_sig,                                       &
-                     & loc_sig_sur,                                   &
-                     & loc_sig_ben
+                WRITE(unit=out,fmt='(f12.3,e20.12,4f12.3)',iostat=ios) &
+                     & loc_t,                                          &
+                     & loc_ocn_tot_M*loc_frac,                         &
+                     & loc_sig,                                        &
+                     & loc_sig_sur,                                    &
+                     & loc_sig_ben,                                    &
+                     & loc_sig_opn
                 call check_iostat(ios,__LINE__,__FILE__)
                 CLOSE(unit=out,iostat=ios)
                 call check_iostat(ios,__LINE__,__FILE__)
@@ -1151,49 +1173,56 @@ CONTAINS
           SELECT CASE (ic)
           CASE (ic_conc_CO2,ic_conc_HCO3,ic_conc_CO3)
              if (ocn_select(io_DIC_14C)) then
-                loc_sig = int_carb_sur_sig(ic)/int_t_sig
+                loc_sig_sur = int_carb_sur_sig(ic)/int_t_sig
+                loc_sig_opn = int_carb_opn_sig(ic)/int_t_sig
                 call check_unit(out,__LINE__,__FILE__)
                 OPEN(unit=out,file=loc_filename,action='write',status='old',position='append',iostat=ios)
                 call check_iostat(ios,__LINE__,__FILE__)
-                WRITE(unit=out,fmt='(f12.3,e15.7,2f12.3)',iostat=ios) &
+                WRITE(unit=out,fmt='(f12.3,e15.7,2f12.3,e15.7)',iostat=ios) &
                      & loc_t, &
-                     & loc_sig, &
-                     & fun_calc_isotope_delta(loc_sig,loc_carbisor(ic - 1)*loc_sig,const_standards(11),.FALSE.,const_nulliso), &
-                     & fun_calc_isotope_delta(loc_sig,loc_carbisor(ic + 3)*loc_sig,const_standards(12),.FALSE.,const_nulliso)
+                     & loc_sig_sur, &
+                     & fun_calc_isotope_delta&
+                     & (loc_sig_sur,loc_carbisor(ic - 1)*loc_sig_sur,const_standards(11),.FALSE.,const_nulliso), &
+                     & fun_calc_isotope_delta &
+                     & (loc_sig_sur,loc_carbisor(ic + 3)*loc_sig_sur,const_standards(12),.FALSE.,const_nulliso), &
+                     & loc_sig_opn
                 call check_iostat(ios,__LINE__,__FILE__)
                 CLOSE(unit=out,iostat=ios)
                 call check_iostat(ios,__LINE__,__FILE__)
              elseif (ocn_select(io_DIC_13C)) then
-                loc_sig = int_carb_sur_sig(ic)/int_t_sig
+                loc_sig_sur = int_carb_sur_sig(ic)/int_t_sig
+                loc_sig_opn = int_carb_opn_sig(ic)/int_t_sig
                 call check_unit(out,__LINE__,__FILE__)
                 OPEN(unit=out,file=loc_filename,action='write',status='old',position='append',iostat=ios)
                 WRITE(unit=out,fmt='(f12.3,e15.7,f12.3)',iostat=ios) &
                      & loc_t, &
-                     & loc_sig, &
-                     & fun_calc_isotope_delta(loc_sig,loc_carbisor(ic - 1)*loc_sig,const_standards(11),.FALSE.,const_nulliso)
+                     & loc_sig_sur, &
+                     & fun_calc_isotope_delta &
+                     & (loc_sig_sur,loc_carbisor(ic - 1)*loc_sig_sur,const_standards(11),.FALSE.,const_nulliso), &
+                     & loc_sig_opn
                 call check_iostat(ios,__LINE__,__FILE__)
                 CLOSE(unit=out,iostat=ios)
                 call check_iostat(ios,__LINE__,__FILE__)
              else
-                loc_sig = int_carb_sur_sig(ic)/int_t_sig
+                loc_sig_sur = int_carb_sur_sig(ic)/int_t_sig
                 call check_unit(out,__LINE__,__FILE__)
                 OPEN(unit=out,file=loc_filename,action='write',status='old',position='append',iostat=ios)
                 call check_iostat(ios,__LINE__,__FILE__)
                 WRITE(unit=out,fmt='(f12.3,e15.7)',iostat=ios) &
                      & loc_t, &
-                     & loc_sig
+                     & loc_sig_sur
                 call check_iostat(ios,__LINE__,__FILE__)
                 CLOSE(unit=out,iostat=ios)
                 call check_iostat(ios,__LINE__,__FILE__)
              end if
           case default
-             loc_sig = int_carb_sur_sig(ic)/int_t_sig
+                loc_sig_sur = int_carb_sur_sig(ic)/int_t_sig
              call check_unit(out,__LINE__,__FILE__)
              OPEN(unit=out,file=loc_filename,action='write',status='old',position='append',iostat=ios)
              call check_iostat(ios,__LINE__,__FILE__)
              WRITE(unit=out,fmt='(f12.3,e15.7)',iostat=ios) &
                   & loc_t, &
-                  & loc_sig
+                  & loc_sig_sur
              call check_iostat(ios,__LINE__,__FILE__)
              CLOSE(unit=out,iostat=ios)
              call check_iostat(ios,__LINE__,__FILE__)

--- a/genie-biogem/src/fortran/biogem_data_ascii.f90
+++ b/genie-biogem/src/fortran/biogem_data_ascii.f90
@@ -48,9 +48,9 @@ CONTAINS
                 loc_string = '% time (yr) / ' //&
                      & 'global total ' //TRIM(string_ocn(io))//' (mol) / ' //&
                      & 'global mean ' //TRIM(string_ocn(io))//' (mol kg-1) / ' //&
-                     & 'surface (ice-free)' //TRIM(string_ocn(io))//' (mol kg-1) / ' //&
+                     & 'surface (ice-free) ' //TRIM(string_ocn(io))//' (mol kg-1) / ' //&
                      & 'benthic ' //TRIM(string_ocn(io))//' (mol kg-1) / ' //&
-                     & 'surface' //TRIM(string_ocn(io))//' (mol kg-1)'
+                     & 'surface ' //TRIM(string_ocn(io))//' (mol kg-1)'
              CASE (n_itype_min:n_itype_max)
                 loc_string = '% time (yr) / ' //&
                      & 'global total '//TRIM(string_ocn(io))//' (mol) / ' //&
@@ -337,9 +337,13 @@ CONTAINS
                 loc_string = '% time (yr) / surface '//TRIM(string_carb(ic))//' (mol kg-1)'
              end if
           CASE (ic_fug_CO2)
-             loc_string = '% time (yr) / surface '//TRIM(string_carb(ic))//' (atm)'
+             loc_string = '% time (yr) / ' //&
+                  & 'surface (ice-free) '//TRIM(string_carb(ic))//' (atm) / ' //&
+                  & 'surface '//TRIM(string_carb(ic))//' (atm)'
           case default
-             loc_string = '% time (yr) / surface '//TRIM(string_carb(ic))//' (mol kg-1)'
+             loc_string = '% time (yr) / ' //&
+                  & 'surface (ice-free) '//TRIM(string_carb(ic))//' (mol kg-1) / ' //&
+                  & 'surface '//TRIM(string_carb(ic))//' (mol kg-1)'
           end SELECT
           call check_unit(out,__LINE__,__FILE__)
           OPEN(unit=out,file=loc_filename,action='write',status='replace',iostat=ios)
@@ -1033,13 +1037,13 @@ CONTAINS
              end If
              IF (ctrl_data_save_sig_ocn_sur .OR. (par_data_save_level > 3)) THEN
                 If (io == io_T) then
-                   loc_sig_sur = int_ocn_sur_sig(io)/int_t_sig - const_zeroC
                    loc_sig_opn = int_ocn_opn_sig(io)/int_t_sig - const_zeroC
                    loc_sig_ben = int_ocn_ben_sig(io)/int_t_sig - const_zeroC
+                   loc_sig_sur = int_ocn_sur_sig(io)/int_t_sig - const_zeroC
                 else
-                   loc_sig_sur = int_ocn_sur_sig(io)/int_t_sig
                    loc_sig_opn = int_ocn_opn_sig(io)/int_t_sig
                    loc_sig_ben = int_ocn_ben_sig(io)/int_t_sig
+                   loc_sig_sur = int_ocn_sur_sig(io)/int_t_sig
                 end If
                 call check_unit(out,__LINE__,__FILE__)
                 OPEN(unit=out,file=loc_filename,action='write',status='old',position='append',iostat=ios)
@@ -1047,9 +1051,9 @@ CONTAINS
                 WRITE(unit=out,fmt='(f12.3,4f12.6)',iostat=ios) &
                      & loc_t,                                   &
                      & loc_sig,                                 &
-                     & loc_sig_sur,                             &
+                     & loc_sig_opn,                             &
                      & loc_sig_ben,                             &
-                     & loc_sig_opn
+                     & loc_sig_sur
                 call check_iostat(ios,__LINE__,__FILE__)
                 CLOSE(unit=out,iostat=ios)
                 call check_iostat(ios,__LINE__,__FILE__)
@@ -1067,9 +1071,9 @@ CONTAINS
           CASE (1)
              loc_sig = int_ocn_sig(io)/int_t_sig
              IF (ctrl_data_save_sig_ocn_sur) THEN
-                loc_sig_sur = int_ocn_sur_sig(io)/int_t_sig
                 loc_sig_opn = int_ocn_opn_sig(io)/int_t_sig
                 loc_sig_ben = int_ocn_ben_sig(io)/int_t_sig
+                loc_sig_sur = int_ocn_sur_sig(io)/int_t_sig
                 call check_unit(out,__LINE__,__FILE__)
                 OPEN(unit=out,file=loc_filename,action='write',status='old',position='append',iostat=ios)
                 call check_iostat(ios,__LINE__,__FILE__)
@@ -1077,9 +1081,9 @@ CONTAINS
                      & loc_t,                                          &
                      & loc_ocn_tot_M*loc_sig,                          &
                      & loc_sig,                                        &
-                     & loc_sig_sur,                                    &
+                     & loc_sig_opn,                                    &
                      & loc_sig_ben,                                    &
-                     & loc_sig_opn
+                     & loc_sig_sur
                 call check_iostat(ios,__LINE__,__FILE__)
                 CLOSE(unit=out,iostat=ios)
                 call check_iostat(ios,__LINE__,__FILE__)                
@@ -1102,15 +1106,15 @@ CONTAINS
              loc_sig      = fun_calc_isotope_delta(loc_tot,loc_frac,loc_standard,.FALSE.,const_nulliso)
              IF (ctrl_data_save_sig_ocn_sur) THEN
                 loc_standard = const_standards(ocn_type(io))
-                loc_tot_sur    = int_ocn_sur_sig(ocn_dep(io))/int_t_sig
-                loc_frac_sur   = int_ocn_sur_sig(io)/int_t_sig
-                loc_sig_sur    = fun_calc_isotope_delta(loc_tot_sur,loc_frac_sur,loc_standard,.FALSE.,const_nulliso)
                 loc_tot_opn    = int_ocn_opn_sig(ocn_dep(io))/int_t_sig
                 loc_frac_opn   = int_ocn_opn_sig(io)/int_t_sig
                 loc_sig_opn    = fun_calc_isotope_delta(loc_tot_opn,loc_frac_opn,loc_standard,.FALSE.,const_nulliso)
                 loc_tot_ben    = int_ocn_ben_sig(ocn_dep(io))/int_t_sig
                 loc_frac_ben   = int_ocn_ben_sig(io)/int_t_sig
                 loc_sig_ben    = fun_calc_isotope_delta(loc_tot_ben,loc_frac_ben,loc_standard,.FALSE.,const_nulliso)
+                loc_tot_sur    = int_ocn_sur_sig(ocn_dep(io))/int_t_sig
+                loc_frac_sur   = int_ocn_sur_sig(io)/int_t_sig
+                loc_sig_sur    = fun_calc_isotope_delta(loc_tot_sur,loc_frac_sur,loc_standard,.FALSE.,const_nulliso)
                 call check_unit(out,__LINE__,__FILE__)
                 OPEN(unit=out,file=loc_filename,action='write',status='old',position='append',iostat=ios)
                 call check_iostat(ios,__LINE__,__FILE__)
@@ -1118,9 +1122,9 @@ CONTAINS
                      & loc_t,                                          &
                      & loc_ocn_tot_M*loc_frac,                         &
                      & loc_sig,                                        &
-                     & loc_sig_sur,                                    &
+                     & loc_sig_opn,                                    &
                      & loc_sig_ben,                                    &
-                     & loc_sig_opn
+                     & loc_sig_sur
                 call check_iostat(ios,__LINE__,__FILE__)
                 CLOSE(unit=out,iostat=ios)
                 call check_iostat(ios,__LINE__,__FILE__)
@@ -1146,18 +1150,18 @@ CONTAINS
        IF (ctrl_data_save_sig_ocn_sur) THEN
           if (ocn_select(io_DIC_13C)) then
              call sub_calc_carb_r13C( &
-                  & int_ocn_sur_sig(io_T)/int_t_sig, &
-                  & int_ocn_sur_sig(io_DIC)/int_t_sig, &
-                  & int_ocn_sur_sig(io_DIC_13C)/int_t_sig, &
+                  & int_ocn_opn_sig(io_T)/int_t_sig, &
+                  & int_ocn_opn_sig(io_DIC)/int_t_sig, &
+                  & int_ocn_opn_sig(io_DIC_13C)/int_t_sig, &
                   & int_carb_sur_sig(:)/int_t_sig, &
                   & loc_carbisor(:) &
                   & )
           end IF
           if (ocn_select(io_DIC_14C)) then
              call sub_calc_carb_r14C( &
-                  & int_ocn_sur_sig(io_T)/int_t_sig, &
-                  & int_ocn_sur_sig(io_DIC)/int_t_sig, &
-                  & int_ocn_sur_sig(io_DIC_14C)/int_t_sig, &
+                  & int_ocn_opn_sig(io_T)/int_t_sig, &
+                  & int_ocn_opn_sig(io_DIC)/int_t_sig, &
+                  & int_ocn_opn_sig(io_DIC_14C)/int_t_sig, &
                   & int_carb_sur_sig(:)/int_t_sig, &
                   & loc_carbisor(:) &
                   & )
@@ -1173,19 +1177,19 @@ CONTAINS
           SELECT CASE (ic)
           CASE (ic_conc_CO2,ic_conc_HCO3,ic_conc_CO3)
              if (ocn_select(io_DIC_14C)) then
-                loc_sig_sur = int_carb_sur_sig(ic)/int_t_sig
                 loc_sig_opn = int_carb_opn_sig(ic)/int_t_sig
+                loc_sig_sur = int_carb_sur_sig(ic)/int_t_sig
                 call check_unit(out,__LINE__,__FILE__)
                 OPEN(unit=out,file=loc_filename,action='write',status='old',position='append',iostat=ios)
                 call check_iostat(ios,__LINE__,__FILE__)
                 WRITE(unit=out,fmt='(f12.3,e15.7,2f12.3,e15.7)',iostat=ios) &
                      & loc_t, &
-                     & loc_sig_sur, &
+                     & loc_sig_opn, &
                      & fun_calc_isotope_delta&
-                     & (loc_sig_sur,loc_carbisor(ic - 1)*loc_sig_sur,const_standards(11),.FALSE.,const_nulliso), &
+                     & (loc_sig_opn,loc_carbisor(ic - 1)*loc_sig_opn,const_standards(11),.FALSE.,const_nulliso), &
                      & fun_calc_isotope_delta &
-                     & (loc_sig_sur,loc_carbisor(ic + 3)*loc_sig_sur,const_standards(12),.FALSE.,const_nulliso), &
-                     & loc_sig_opn
+                     & (loc_sig_opn,loc_carbisor(ic + 3)*loc_sig_opn,const_standards(12),.FALSE.,const_nulliso), &
+                     & loc_sig_sur
                 call check_iostat(ios,__LINE__,__FILE__)
                 CLOSE(unit=out,iostat=ios)
                 call check_iostat(ios,__LINE__,__FILE__)
@@ -1196,32 +1200,36 @@ CONTAINS
                 OPEN(unit=out,file=loc_filename,action='write',status='old',position='append',iostat=ios)
                 WRITE(unit=out,fmt='(f12.3,e15.7,f12.3)',iostat=ios) &
                      & loc_t, &
-                     & loc_sig_sur, &
+                     & loc_sig_opn, &
                      & fun_calc_isotope_delta &
-                     & (loc_sig_sur,loc_carbisor(ic - 1)*loc_sig_sur,const_standards(11),.FALSE.,const_nulliso), &
-                     & loc_sig_opn
+                     & (loc_sig_opn,loc_carbisor(ic - 1)*loc_sig_opn,const_standards(11),.FALSE.,const_nulliso), &
+                     & loc_sig_sur
                 call check_iostat(ios,__LINE__,__FILE__)
                 CLOSE(unit=out,iostat=ios)
                 call check_iostat(ios,__LINE__,__FILE__)
              else
+                loc_sig_opn = int_carb_opn_sig(ic)/int_t_sig
                 loc_sig_sur = int_carb_sur_sig(ic)/int_t_sig
                 call check_unit(out,__LINE__,__FILE__)
                 OPEN(unit=out,file=loc_filename,action='write',status='old',position='append',iostat=ios)
                 call check_iostat(ios,__LINE__,__FILE__)
-                WRITE(unit=out,fmt='(f12.3,e15.7)',iostat=ios) &
+                WRITE(unit=out,fmt='(f12.3,2e15.7)',iostat=ios) &
                      & loc_t, &
+                     & loc_sig_opn, &
                      & loc_sig_sur
                 call check_iostat(ios,__LINE__,__FILE__)
                 CLOSE(unit=out,iostat=ios)
                 call check_iostat(ios,__LINE__,__FILE__)
              end if
           case default
+                loc_sig_opn = int_carb_opn_sig(ic)/int_t_sig
                 loc_sig_sur = int_carb_sur_sig(ic)/int_t_sig
              call check_unit(out,__LINE__,__FILE__)
              OPEN(unit=out,file=loc_filename,action='write',status='old',position='append',iostat=ios)
              call check_iostat(ios,__LINE__,__FILE__)
-             WRITE(unit=out,fmt='(f12.3,e15.7)',iostat=ios) &
+             WRITE(unit=out,fmt='(f12.3,2e15.7)',iostat=ios) &
                   & loc_t, &
+                  & loc_sig_opn, &
                   & loc_sig_sur
              call check_iostat(ios,__LINE__,__FILE__)
              CLOSE(unit=out,iostat=ios)

--- a/genie-biogem/src/fortran/biogem_lib.f90
+++ b/genie-biogem/src/fortran/biogem_lib.f90
@@ -1048,8 +1048,10 @@ MODULE biogem_lib
   REAL,DIMENSION(n_sed)::int_focnsed_sig                         !
   REAL,DIMENSION(n_ocn)::int_fsedocn_sig                         !
   REAL,DIMENSION(n_ocn)::int_ocn_sur_sig                         !
+  REAL,DIMENSION(n_ocn)::int_ocn_opn_sig                         !
   REAL,DIMENSION(n_ocn)::int_ocn_ben_sig                         !
   REAL,DIMENSION(n_carb)::int_carb_sur_sig                       !
+  REAL,DIMENSION(n_carb)::int_carb_opn_sig                       !
   REAL,DIMENSION(n_carb)::int_carb_ben_sig                       !
   REAL::int_misc_age_sig                                         !
   real::int_misc_age_sur_sig,int_misc_age_ben_sig                !
@@ -1067,8 +1069,8 @@ MODULE biogem_lib
   REAL,DIMENSION(n_atm)::int_diag_forcing_sig                    ! forcing diagnostics
   REAL,DIMENSION(n_diag_misc_2D)::int_diag_misc_2D_sig           !
   ! misc
-  real::int_misc_ocn_solfor_sig                                  !
-  real::int_misc_ocn_fxsw_sig                                    !
+  real::int_misc_ocn_solfor_sig,int_misc_opn_solfor_sig          !
+  real::int_misc_ocn_fxsw_sig,int_misc_opn_fxsw_sig              !
   ! 'snap-shot' time-series arrays
   real::snap_misc_ocn_solfor_N_sig                               !
   real::snap_misc_ocn_solfor_S_sig                               !

--- a/genie-main/runmuffin.t100.sh
+++ b/genie-main/runmuffin.t100.sh
@@ -120,6 +120,10 @@ else
     echo " CANNOT be found :("
     exit 1
 fi
+if [ $(expr length "$3") -gt 127 ] ; then
+    echo "Usage: '$3' 3rd parameter must be less than 128 characters in length"
+    exit 65
+fi
 if [ -n "$5" ]; then
     if test -e $RESTARTPATH
     then
@@ -131,6 +135,10 @@ if [ -n "$5" ]; then
         echo $RESTARTPATH
         echo " CANNOT be found :("
         exit 1
+    fi
+    if [ $(expr length "$5") -gt 127 ] ; then
+        echo "Usage: '$5' 5th parameter must be less than 128 characters in length"
+        exit 65
     fi
 else
     echo "   #5 NO restart specified"
@@ -152,6 +160,7 @@ echo EXPID=$RUNID >> $CONFIGPATH/$CONFIGNAME
 LONS=$(grep -o '$(DEFINE)GOLDSTEINNLONS=..\>' $CONFIGPATH/$MODELID".config" | sed -e s/.*=//)
 LATS=$(grep -o '$(DEFINE)GOLDSTEINNLATS=..\>' $CONFIGPATH/$MODELID".config" | sed -e s/.*=//)
 LEVS=$(grep -o '$(DEFINE)GOLDSTEINNLEVS=..\>' $CONFIGPATH/$MODELID".config" | sed -e s/.*=//)
+IGRID=$(grep -o 'go_grid=.' $CONFIGPATH/$MODELID".config" | sed -e s/.*=//)
 # filter single digit format level ('8' vs. '08')
 ###if [ "$LEVS" == "8\'" ] || [ "$LEVS" == "8\"" ]; then
 if [ "$LEVS" != "32" ] && [ "$LEVS" != "24" ] && [ "$LEVS" != "16" ] && [ "$LEVS" != "08" ]; then
@@ -163,28 +172,46 @@ if [ $LONS -eq 36 ] && [ $LEVS -eq 16 ]; then
     let dbiostp=2
 elif [ $LONS -eq 36 ] && [ $LEVS -eq 8 ]; then
     let N_TIMESTEPS=100
-    let dbiostp=5
+    let dbiostp=4
 elif [ $LONS -eq 18 ] && [ $LEVS -eq 16 ]; then
     let N_TIMESTEPS=50
-    let dbiostp=2
+    let dbiostp=1
 elif [ $LONS -eq 18 ] && [ $LEVS -eq 8 ]; then
     let N_TIMESTEPS=50
-    let dbiostp=5
+    let dbiostp=2
+elif [ $LONS -eq 12 ] && [ $LEVS -eq 8 ]; then
+    let N_TIMESTEPS=50
+    let dbiostp=2
+elif [ $LONS -eq 36 ] && [ $LEVS -eq 32 ]; then
+    let N_TIMESTEPS=100
+    let dbiostp=1
+elif [ $LONS -eq 48 ] && [ $LEVS -eq 16 ]; then
+    let N_TIMESTEPS=100
+    let dbiostp=2
 else
     let N_TIMESTEPS=100
     let dbiostp=1
 fi
+if [ $IGRID -eq 1 ]; then
+    echo "   Making non-equal area grid modifications to time-stepping, igrid: " $IGRID
+    N_TIMESTEPS="$(echo "4*$N_TIMESTEPS" | bc -l)"
+    dbiostp="$(echo "4*$dbiostp" | bc -l)"
+    let datmstp=5
+else
+    let datmstp=5
+fi
 echo "   Setting time-stepping [GOLDSTEIN, BIOGEM:GOLDSTEIN]: " $N_TIMESTEPS $dbiostp
 # define primary model time step
-# c-goldstein; ma_genie_timestep = 365.25*24.0/(5*96) * 3600.0 (GOLDSTEIN year length)
-# ma_genie_timestep=65745.0
-dstp="$(echo "3600.0*24.0*365.25/5.0/$N_TIMESTEPS" | bc -l)"
+# c-goldstein; e.g. ma_genie_timestep = 365.25*24.0/(5*96) * 3600.0 (GOLDSTEIN year length)
+#                => ma_genie_timestep=65745.0
+dstp="$(echo "3600.0*24.0*365.25/$datmstp/$N_TIMESTEPS" | bc -l)"
+echo "   Setting primary model time step: " $dstp
 # write primary model time step
 echo ma_genie_timestep=$dstp >> $CONFIGPATH/$CONFIGNAME
 # write relative time-stepping
-echo ma_ksic_loop=5 >> $CONFIGPATH/$CONFIGNAME
-echo ma_kocn_loop=5 >> $CONFIGPATH/$CONFIGNAME
-echo ma_klnd_loop=5 >> $CONFIGPATH/$CONFIGNAME
+echo ma_ksic_loop=$datmstp >> $CONFIGPATH/$CONFIGNAME
+echo ma_kocn_loop=$datmstp >> $CONFIGPATH/$CONFIGNAME
+echo ma_klnd_loop=$datmstp >> $CONFIGPATH/$CONFIGNAME
 echo ma_conv_kocn_kecogem=$dbiostp >> $CONFIGPATH/$CONFIGNAME
 echo ma_conv_kocn_katchem=$dbiostp >> $CONFIGPATH/$CONFIGNAME
 echo ma_conv_kocn_kbiogem=$dbiostp >> $CONFIGPATH/$CONFIGNAME
@@ -196,7 +223,7 @@ echo bg_par_misc_t_runtime=$RUNLENGTH >> $CONFIGPATH/$CONFIGNAME
 # set SEDGEM sediment age
 echo sg_par_misc_t_runtime=$RUNLENGTH >> $CONFIGPATH/$CONFIGNAME
 # set overall GENIE run length
-let stp=$RUNLENGTH*5*$N_TIMESTEPS
+let stp=$RUNLENGTH*$datmstp*$N_TIMESTEPS
 echo ma_koverall_total=$stp >> $CONFIGPATH/$CONFIGNAME
 echo ma_dt_write=$stp >> $CONFIGPATH/$CONFIGNAME
 # set 'health check' frequency [NOTE: a '+1' in effect disables this feature]
@@ -204,25 +231,25 @@ let stp=$RUNLENGTH*$N_TIMESTEPS
 echo ea_3=$stp >> $CONFIGPATH/$CONFIGNAME
 echo go_3=$stp >> $CONFIGPATH/$CONFIGNAME
 echo gs_3=$stp >> $CONFIGPATH/$CONFIGNAME
-echo ents_3=$stp >> $CONFIGPATH/$CONFIGNAME
+echo el_3=$stp >> $CONFIGPATH/$CONFIGNAME
 # set climate model component restart frequency
 let stp=$RUNLENGTH*$N_TIMESTEPS
 echo ea_4=$stp >> $CONFIGPATH/$CONFIGNAME
 echo go_4=$stp >> $CONFIGPATH/$CONFIGNAME
 echo gs_4=$stp >> $CONFIGPATH/$CONFIGNAME
-echo ents_4=$stp >> $CONFIGPATH/$CONFIGNAME
+echo el_4=$stp >> $CONFIGPATH/$CONFIGNAME
 # set 'time series' frequency [NOTE: a '+1' in effect disables this feature]
 let stp=$RUNLENGTH*$N_TIMESTEPS+1
 echo ea_5=$stp >> $CONFIGPATH/$CONFIGNAME
 echo go_5=$stp >> $CONFIGPATH/$CONFIGNAME
 echo gs_5=$stp >> $CONFIGPATH/$CONFIGNAME
-echo ents_5=$stp >> $CONFIGPATH/$CONFIGNAME
+echo el_5=$stp >> $CONFIGPATH/$CONFIGNAME
 # set 'an average' frequency [NOTE: a '+1' in effect disables this feature]
 let stp=$RUNLENGTH*$N_TIMESTEPS+1
 echo ea_6=$stp >> $CONFIGPATH/$CONFIGNAME
 echo go_6=$stp >> $CONFIGPATH/$CONFIGNAME
 echo gs_6=$stp >> $CONFIGPATH/$CONFIGNAME
-echo ents_6=$stp >> $CONFIGPATH/$CONFIGNAME
+echo el_6=$stp >> $CONFIGPATH/$CONFIGNAME
 # SET CLIMATE COMPONENTS TIME-STEPS PER YEAR
 echo ea_9=$N_TIMESTEPS >> $CONFIGPATH/$CONFIGNAME
 echo go_9=$N_TIMESTEPS >> $CONFIGPATH/$CONFIGNAME
@@ -243,8 +270,8 @@ echo gs_15=y >> $CONFIGPATH/$CONFIGNAME
 echo ea_29=rst >> $CONFIGPATH/$CONFIGNAME
 echo go_17=rst >> $CONFIGPATH/$CONFIGNAME
 echo gs_12=rst >> $CONFIGPATH/$CONFIGNAME
-echo ents_17="rst" >> $CONFIGPATH/$CONFIGNAME
-echo ents_24="rst.sland" >> $CONFIGPATH/$CONFIGNAME
+echo el_17="rst" >> $CONFIGPATH/$CONFIGNAME
+echo el_24="rst.sland" >> $CONFIGPATH/$CONFIGNAME
 #
 # (6) CONFIGURE USE OF RESTART
 # -----------------------------
@@ -293,7 +320,7 @@ else
   echo ea_7=n >> $CONFIGPATH/$CONFIGNAME
   echo go_7=n >> $CONFIGPATH/$CONFIGNAME
   echo gs_7=n >> $CONFIGPATH/$CONFIGNAME
-  echo ents_7=n >> $CONFIGPATH/$CONFIGNAME
+  echo el_7=n >> $CONFIGPATH/$CONFIGNAME
   echo ac_ctrl_continuing=f >> $CONFIGPATH/$CONFIGNAME
   echo bg_ctrl_continuing=f >> $CONFIGPATH/$CONFIGNAME
   echo sg_ctrl_continuing=f >> $CONFIGPATH/$CONFIGNAME
@@ -313,8 +340,8 @@ echo bg_ctrl_force_oldformat=.false. >> $CONFIGPATH/$CONFIGNAME
 # (8) INCORPORATE RUN CONFIGURATION
 # ---------------------------------
 echo "   Make safe goin format"
-dos2unix $GOIN
-#tr ‘\r’ ‘\n’ < $GOIN
+#dos2unix $GOIN
+#tr â€˜\râ€™ â€˜\nâ€™ < $GOIN
 cat $GOIN >> $CONFIGPATH/$CONFIGNAME
 #
 # (9) GO!
@@ -325,7 +352,7 @@ echo ">> Here we go ..."
 echo ""
 cd $BINARYPATH
 # test for change of base-config
-if test -e 'current_config.dat'
+if test -e 'current_config.dat' 
 then
     current_config=$(<'current_config.dat')
     if [ "$current_config" != "$MODELID" ]; then
@@ -339,6 +366,8 @@ else
     echo ">> WARNING: No record of last base-config (file: current_config.dat): CONTINUING ..."
     echo ""
     sleep 4
+    make cleanall
+    echo "$MODELID" > 'current_config.dat'
 fi
 ./genie_example.job -O -f $CONFIGPATH/$CONFIGNAME
 # Clean up and archive


### PR DESCRIPTION
Now here is an admission ...

In commit 8e340e5b171b7d86d3e47b0c163200fab623aa67
'revised color and preformed tracer behavior' on 13th May:

In addition to what I was meant to be doing (fixed up the preformed tracer code), I changed the averaging of surface time-series variables, from an ice-free basis, to an entire ocean surface averaging basis.
This changed the values (for climates with sea-ice) and confused the hell out of me as I thought something had gone 'wrong' with experiments post this commit.

I have hence partially un-done this, so that in the same column of sur time-series output as before, the same ice-free ocean surface average appears.
An additional new last row now appears, which is the whole ocean surface average (which should be the same as the ocean-free number only when there is no sea-ice present).

To Test:
(1) checkout
(2) make testbiogem
(3) re-run the first ca. 10 years of any experiment(s) pre-dating 13th May 2019, and confirm that the surface ocean ice-free time-series values are the same.

NOTE: Surface (and benthic) means are only reported for ocn tracers. There is also a specific set of sur carbonate chemistry time-series output. (All depending on what output options are selected.)
NOTE: The 2 different surface averaged columns are distinguished:
'surface (ice-free)' vs. just 'surface'
