### PR TITLE
Updated rate constants for methanotrophy

### DIFF
--- a/genie-main/src/xml-config/xml/definition.xml
+++ b/genie-main/src/xml-config/xml/definition.xml
@@ -4341,7 +4341,7 @@ par_bio_red_PC_alpha2 scales the offset of 6.0e-3 of Galbraith & Martiny, 2015 C
                         <description>Specific CH4 oxidation rate (d-1)</description>
                     </param>
                     <param name="par_bio_remin_AER_kAER">
-            <value datatype="real">0.40</value>
+            <value datatype="real">0.10</value>
                         <description>Aerobic methanotrophy rate constant (yr-1)</description>
                     </param>
                     <param name="par_bio_remin_AER_Km_O2">
@@ -4361,8 +4361,8 @@ par_bio_red_PC_alpha2 scales the offset of 6.0e-3 of Galbraith & Martiny, 2015 C
                         <description>AER biological energy quantum (kJ mol-1)</description>
                     </param>
                     <param name="par_bio_remin_AOM_kAOM">
-            <value datatype="real">0.035</value>
-                        <description>AOM rate constant (yr-1) (see Olson et al., 2016)</description>
+            <value datatype="real">0.01</value>
+                        <description>AOM rate constant (yr-1) (see also Olson et al., 2016)</description>
                     </param>
                     <param name="par_bio_remin_AOM_Km_SO4">
             <value datatype="real">500.0E-6</value>


### PR DESCRIPTION
Reduced default rate constants for aerobic (par_bio_remin_AER_kAER) and anaerobic (par_bio_remin_AOM_kAOM) methanotrophy for consistency with most recent runs for GMD methane paper.