### PR TITLE
Fixed install error on Mac - needs checking on other platforms

### DIFF
--- a/genie-ecogem/src/fortran/ecogem_box.f90
+++ b/genie-ecogem/src/fortran/ecogem_box.f90
@@ -542,7 +542,7 @@ CONTAINS
   END SUBROUTINE check_egbg_compatible
   ! ****************************************************************************************************************************** !
   ! convert a word to lower case
-  elemental subroutine lower_case(word)
+  elemental impure subroutine lower_case(word)
     character (len=*) , intent(in out) :: word
     integer                            :: i,ic,nlen
     nlen = len(word)

--- a/genie-ecogem/src/fortran/ecogem_box.f90
+++ b/genie-ecogem/src/fortran/ecogem_box.f90
@@ -542,7 +542,7 @@ CONTAINS
   END SUBROUTINE check_egbg_compatible
   ! ****************************************************************************************************************************** !
   ! convert a word to lower case
-  elemental impure subroutine lower_case(word)
+  subroutine lower_case(word)
     character (len=*) , intent(in out) :: word
     integer                            :: i,ic,nlen
     nlen = len(word)


### PR DESCRIPTION
'elemental' subroutine 'lower_case' was causing a compile error, related to the 'pure' status of the elemental class (pure subroutines have no 'side-effects', whatever that means). I have specified it should 'impure' and it now passes testbiogem.

Needs checking this does not screw up compilation on other platforms