### PR TITLE
_pHFIX2 -> master

### DIFF
--- a/genie-biogem/src/fortran/biogem.f90
+++ b/genie-biogem/src/fortran/biogem.f90
@@ -2957,7 +2957,7 @@ SUBROUTINE diag_biogem_timeslice( &
         if_save3: if (dum_save) then
 
            ! reconstruct local interface fluxes and update whole-ocean carbonate equilibrium
-           IF (opt_select(iopt_select_carbchem)) THEN
+           IF (opt_select(iopt_select_carbchem) .AND. ctrl_data_save_slice_carb_update) THEN
               DO i=1,n_i
                  DO j=1,n_j
                     loc_k1 = goldstein_k1(i,j)

--- a/genie-biogem/src/fortran/biogem_data.f90
+++ b/genie-biogem/src/fortran/biogem_data.f90
@@ -454,6 +454,7 @@ CONTAINS
        print*,'Number of timesteps in sub-inteval saving           : ',par_data_save_slice_n
        print*,'Auto save at run end?                               : ',ctrl_data_save_slice_autoend
        print*,'Save cdrmip data (only)?                            : ',ctrl_data_save_slice_cdrmip
+       print*,'Update carbonate chemistry for saving?              : ',ctrl_data_save_slice_carb_update
        ! --- DATA SAVING: TIME-SERIES -------------------------------------------------------------------------------------------- !
        print*,'--- BIOGEM DATA SAVING: TIME-SERIES ----------------'
        print*,'Atmospheric (interface) composition?                : ',ctrl_data_save_sig_ocnatm

--- a/genie-biogem/src/fortran/biogem_lib.f90
+++ b/genie-biogem/src/fortran/biogem_lib.f90
@@ -630,6 +630,8 @@ MODULE biogem_lib
   NAMELIST /ini_biogem_nml/ctrl_data_save_slice_autoend
   LOGICAL::ctrl_data_save_slice_cdrmip                           ! save cdrmip data (only)?
   NAMELIST /ini_biogem_nml/ctrl_data_save_slice_cdrmip
+  LOGICAL::ctrl_data_save_slice_carb_update                      ! Update carbonate chemistry for saving?
+  NAMELIST /ini_biogem_nml/ctrl_data_save_slice_carb_update
   ! ------------------- DATA SAVING: TIME-SERIES --------------------------------------------------------------------------------- !
   LOGICAL::ctrl_data_save_sig_ocnatm                             ! time-series data save: Atmospheric (interface) composition?
   LOGICAL::ctrl_data_save_sig_ocn                                ! time-series data save: Oceanic composition?

--- a/genie-main/src/xml-config/xml/definition.xml
+++ b/genie-main/src/xml-config/xml/definition.xml
@@ -5395,6 +5395,10 @@ par_bio_red_PC_alpha2 scales the offset of 6.0e-3 of Galbraith & Martiny, 2015 C
 			<value datatype="boolean">.false.</value>
                         <description>Save cdrmip data (only)?</description>
                     </param>
+                    <param name="ctrl_data_save_slice_carb_update">
+			<value datatype="boolean">.true.</value>
+                        <description>Update carbonate chemistry for saving?</description>
+                    </param>
 <!-- DATA SAVING: TIME-SERIES -->
                     <param name="ctrl_data_save_sig_ocnatm">
 			<value datatype="boolean">.true.</value>


### PR DESCRIPTION
Added a new option:
bg_ctrl_data_save_slice_carb_update
that if you set to 
.false.
disables the update calculation of carbonate chemistry associated with the saving of time-slices, 
i.e. the only time pH will then be solved for, is during model initialisation, and at the surface to calculate CO2 exchange with the atmosphere.
Carb chem time-slice data is still saved ... but will not change from the initialised values.
This should avoid most/all carbonate chemistry crash issues.
Nothing else should be affected, but ...
TO TEST:
(1) an experiment involving CH4, as this forces carbon chem to be updated each time-step
(2) any experiment with relatively extreme redox conditions
Simply repeat any relevant experiment for a short period of time, confirm results are unchanged.