### PR TITLE
Porting Python 2 Code to Python 3

### DIFF
--- a/genie-main/GENIEconf.py
+++ b/genie-main/GENIEconf.py
@@ -72,23 +72,25 @@ def get_dom(document_file):
     # Read in config document as DOM
     return xml.dom.minidom.parse(document_file)
 
+
 # select elements matching a hierarchical set of tag names
-def select_elements(dom,names):
+def select_elements(dom, names):
     """ returns a list of elements accoding to a list of hierarchical tag names, i.e. <names[0]><names[1]><names[2]>... """
-    elements = [ dom ]
+    elements = [dom]
     for name in names:
         child_elements = []
         for element in elements:
             all_child_elements = element.childNodes
             for child_element in all_child_elements:
-                if (child_element.nodeName == name):
+                if child_element.nodeName == name:
                     child_elements.append(child_element)
         elements = child_elements
-    return elements    
+    return elements
+
 
 # extract a list of values of a named attribute from a list of
 # elements
-def get_attribute_values(elements,name):
+def get_attribute_values(elements, name):
     """ returns a list of attributes 'name' from a list of elements """
     attribute_values = []
     for element in elements:
@@ -99,108 +101,117 @@ def get_attribute_values(elements,name):
                 attribute_values.append(attribute.value)
     return attribute_values
 
+
 # test if parameter name contains an index and should be interpreted
 # as an element of a 'paramArray' tag
 def is_param_array(param_name):
-    re_param_index = re.compile(r'^(.*)\[([0-9]+)\]$')
+    re_param_index = re.compile(r"^(.*)\[([0-9]+)\]$")
     param_index_match = re_param_index.match(param_name)
-    if (param_index_match is None):
+    if param_index_match is None:
         return False
     else:
-        param_index = [ param_index_match.group(1), param_index_match.group(2) ]
+        param_index = [param_index_match.group(1), param_index_match.group(2)]
         return param_index
+
 
 def split_component_name(component_name):
     # Test if name of component denotes a module or the central
     # 'control' section and return the corresponding 'model' or
     # 'control' element
-    re_model_component = re.compile(r'^([^\[]*)\[([^\]]*)\]$')
+    re_model_component = re.compile(r"^([^\[]*)\[([^\]]*)\]$")
     model_component_match = re_model_component.match(component_name)
-    if (model_component_match):
-        return [ model_component_match.group(1), model_component_match.group(2) ]
+    if model_component_match:
+        return [model_component_match.group(1), model_component_match.group(2)]
     else:
-        return [ component_name, False ]
+        return [component_name, False]
 
-def extract_model_element(dom_config,model_name,definition):
-    if (definition):
-        path = ['definition','parameters','model']
+
+def extract_model_element(dom_config, model_name, definition):
+    if definition:
+        path = ["definition", "parameters", "model"]
     else:
-        path = ['job','parameters','model']
-    elements = select_elements(dom_config,path)
-    element_names = get_attribute_values(elements,'name')
-    if (model_name in element_names):
+        path = ["job", "parameters", "model"]
+    elements = select_elements(dom_config, path)
+    element_names = get_attribute_values(elements, "name")
+    if model_name in element_names:
         return elements[element_names.index(model_name)]
     else:
         return False
 
-def extract_control_element(dom_config,definition):
+
+def extract_control_element(dom_config, definition):
     # There can only be one 'control' element, take the first
     # found
-    if (definition):
-        path = ['definition','parameters','control']
+    if definition:
+        path = ["definition", "parameters", "control"]
     else:
-        path = ['job','parameters','control']
-    element = select_elements(dom_config,path)
-    if (len(element) > 0):
+        path = ["job", "parameters", "control"]
+    element = select_elements(dom_config, path)
+    if len(element) > 0:
         return element[0]
     else:
         return False
 
-def extract_var_section_element(dom_config,element_name,definition):
-    if (definition):
-        path = ['definition',element_name]
+
+def extract_var_section_element(dom_config, element_name, definition):
+    if definition:
+        path = ["definition", element_name]
     else:
-        path = ['job',element_name]
-    element = select_elements(dom_config,path)
-    if (len(element) > 0):
+        path = ["job", element_name]
+    element = select_elements(dom_config, path)
+    if len(element) > 0:
         return element[0]
     else:
         return False
+
 
 def extract_component_element(dom, component_name, definition):
     # Extract component element which has to be modified
     element = False
-    [ component_type, component_name ] = split_component_name(component_name)
-    if (component_type == 'model'):
-        element = extract_model_element(dom,component_name,definition)
-    elif (component_type == 'control'):
-        element = extract_control_element(dom,definition)
+    [component_type, component_name] = split_component_name(component_name)
+    if component_type == "model":
+        element = extract_model_element(dom, component_name, definition)
+    elif component_type == "control":
+        element = extract_control_element(dom, definition)
     return element
+
 
 def add_component_element(dom, component_name):
     # Create and return component element
-    [ component_type, component_name ] = split_component_name(component_name)
+    [component_type, component_name] = split_component_name(component_name)
     # add 'job' element unless there already
-    job_element = select_elements(dom_config, [ 'job' ])
-    if (not job_element):
-        job_element = dom_config.createElement('job')
+    job_element = select_elements(dom_config, ["job"])
+    if not job_element:
+        job_element = dom_config.createElement("job")
         dom_config.appendChild(job_element)
     # add 'parameters' element unless there already
-    parameters_element = select_elements(dom_config, [ 'job', 'parameters' ])
-    if (not parameters_element):
-        parameters_element = dom_config.createElement('parameters')
+    parameters_element = select_elements(dom_config, ["job", "parameters"])
+    if not parameters_element:
+        parameters_element = dom_config.createElement("parameters")
         job_element[0].appendChild(parameters_element)
-    if (component_type == 'model'):
-        component_element = dom_config.createElement('model')
-        component_element.setAttribute('name',component_name)
+    if component_type == "model":
+        component_element = dom_config.createElement("model")
+        component_element.setAttribute("name", component_name)
         parameters_element.appendChild(component_element)
-    elif (component_type == 'control'):
-        component_element = dom_config.createElement('control')
+    elif component_type == "control":
+        component_element = dom_config.createElement("control")
         parameters_element.appendChild(component_element)
     return component_element
 
+
 def add_var_section_element(dom, section_name):
     # add 'job' element unless there already
-    job_element = select_elements(dom_config, [ 'job' ])
-    if (not job_element):
-        job_element = dom_config.createElement('job')
+    job_element = select_elements(dom_config, ["job"])
+    if not job_element:
+        job_element = dom_config.createElement("job")
         dom_config.appendChild(job_element)
     # add element unless there already
-    element = select_elements(dom_config, [ 'job', section_name ])
-    if (not element):
+    element = select_elements(dom_config, ["job", section_name])
+    if not element:
         element = dom_config.createElement(section_name)
         job_element[0].appendChild(element)
     return section_element
+
 
 def extract_value(element):
     nodes = element.childNodes
@@ -212,350 +223,384 @@ def extract_value(element):
             text = text + node.toxml()
     return text
 
+
 ################
 # Main functions
 ################
 
 # Add variable (of different types) to a config file
-def set_var(dom_config, dom_definition, section_name, var_name, var_value, overwrite=True):
+def set_var(
+    dom_config, dom_definition, section_name, var_name, var_value, overwrite=True
+):
     # Test if variable known
-    if (get_var(dom_definition, section_name, var_name, True)):
+    if get_var(dom_definition, section_name, var_name, True):
         # Test if already existing in config
-        if (get_var(dom_config, section_name, var_name, False)):
-            if (overwrite):
+        if get_var(dom_config, section_name, var_name, False):
+            if overwrite:
                 remove_var(dom_config, section_name, var_name)
             else:
                 return False
-        if (section_name == 'make-arg'):
-            section_name = 'build'
-            var_element_name = 'make-arg'
+        if section_name == "make-arg":
+            section_name = "build"
+            var_element_name = "make-arg"
         else:
-            var_element_name = 'var'
-        element = extract_var_section_element(dom_config,section_name, False)
+            var_element_name = "var"
+        element = extract_var_section_element(dom_config, section_name, False)
         # Add section section unless there already
-        if (not element):
-            element = add_var_section_element(dom_config,section_name)
+        if not element:
+            element = add_var_section_element(dom_config, section_name)
         var_element = dom_config.createElement(var_element_name)
         var_element_value = dom_config.createTextNode(str(var_value))
-        var_element.setAttribute('name',var_name)
+        var_element.setAttribute("name", var_name)
         var_element.appendChild(var_element_value)
         element.appendChild(var_element)
         return dom_config
     else:
-        print "Error: Variable '%s' does not exist!" % var_name
+        print("Error: Variable '%s' does not exist!" % var_name)
         return False
+
 
 # Extract value of a var entry either from a config document or the
 # definition document
 def get_var(dom, section_name, var_name, definition=False):
-    if (section_name == 'make-arg'):
-        element_name = 'build'
-        path = [ section_name ]
+    if section_name == "make-arg":
+        element_name = "build"
+        path = [section_name]
     else:
         element_name = section_name
-        path = [ 'var' ]
-    element = extract_var_section_element(dom,element_name,definition)
-    if (not element):
+        path = ["var"]
+    element = extract_var_section_element(dom, element_name, definition)
+    if not element:
         return False
-    var_elements = select_elements(element,path)
-    var_element_names = get_attribute_values(var_elements,'name')
-    if (var_name in var_element_names):
+    var_elements = select_elements(element, path)
+    var_element_names = get_attribute_values(var_elements, "name")
+    if var_name in var_element_names:
         var_element = var_elements[var_element_names.index(var_name)]
     else:
         return False
     value = extract_value(var_element)
     return value
 
+
 # Add parameter to a config file
-def set_param(dom_config, dom_definition, component_name, param_name, param_value, overwrite=True):
+def set_param(
+    dom_config, dom_definition, component_name, param_name, param_value, overwrite=True
+):
     # Test if parameter known
-    if (get_param(dom_definition, component_name, param_name, True)):
+    if get_param(dom_definition, component_name, param_name, True):
         # Test if already existing in config
-        if (get_param(dom_config, component_name, param_name, False)):
-            if (overwrite):
+        if get_param(dom_config, component_name, param_name, False):
+            if overwrite:
                 remove_param(dom_config, component_name, param_name)
             else:
                 return False
-        element = extract_component_element(dom_config,component_name, False)
+        element = extract_component_element(dom_config, component_name, False)
         # Add component section unless there already
-        if (not element):
-            element = add_component_element(dom_config,component_name)
+        if not element:
+            element = add_component_element(dom_config, component_name)
         # Test if a 'paramArray' or a 'param' has to be added
         param_array = is_param_array(param_name)
-        if (param_array):
+        if param_array:
             # Test if 'paramArray' element has to be created first
             param_name = param_array[0]
-            path = ['paramArray']
-            param_elements = select_elements(element,path)
-            param_element_names = get_attribute_values(param_elements,'name')
-            if (param_name in param_element_names):
+            path = ["paramArray"]
+            param_elements = select_elements(element, path)
+            param_element_names = get_attribute_values(param_elements, "name")
+            if param_name in param_element_names:
                 element = param_elements[param_element_names.index(param_name)]
             else:
-                param_array_element = dom_config.createElement('paramArray')
-                param_array_element.setAttribute('name',param_array[0])
+                param_array_element = dom_config.createElement("paramArray")
+                param_array_element.setAttribute("name", param_array[0])
                 element.appendChild(param_array_element)
                 element = param_array_element
-            param_element = dom_config.createElement('param')
-            param_element.setAttribute('index',param_array[1])
+            param_element = dom_config.createElement("param")
+            param_element.setAttribute("index", param_array[1])
             param_element_value = dom_config.createTextNode(str(param_value))
             param_element.appendChild(param_element_value)
             element.appendChild(param_element)
         else:
-            param_element = dom_config.createElement('param')
+            param_element = dom_config.createElement("param")
             param_element_value = dom_config.createTextNode(str(param_value))
-            param_element.setAttribute('name',param_name)
+            param_element.setAttribute("name", param_name)
             param_element.appendChild(param_element_value)
             element.appendChild(param_element)
         return dom_config
     else:
-        print "Error: Parameter '%s' does not exist!" % param_name
+        print("Error: Parameter '%s' does not exist!" % param_name)
         return False
+
 
 # Remove parameter
 def remove_param(dom, component_name, param_name):
     element = extract_component_element(dom, component_name, False)
     param_array = is_param_array(param_name)
-    if (param_array):
+    if param_array:
         param_name = param_array[0]
-        path = ['paramArray']
-        param_elements = select_elements(element,path)
+        path = ["paramArray"]
+        param_elements = select_elements(element, path)
     else:
-        path = ['param']
-        param_elements = select_elements(element,path)
-    param_element_names = get_attribute_values(param_elements,'name')
-    if (param_name in param_element_names):
+        path = ["param"]
+        param_elements = select_elements(element, path)
+    param_element_names = get_attribute_values(param_elements, "name")
+    if param_name in param_element_names:
         param_element = param_elements[param_element_names.index(param_name)]
-        if (param_array):
-            param_array_elements = select_elements(param_element,['param'])
-            param_array_element_indices = get_attribute_values(param_array_elements,'index')
+        if param_array:
+            param_array_elements = select_elements(param_element, ["param"])
+            param_array_element_indices = get_attribute_values(
+                param_array_elements, "index"
+            )
             # if selected, extract description or units from 'paramArray'
             # before proceeding to the selected element of the array
-            if (param_array[1] in param_array_element_indices):
-                param_element = param_array_elements[param_array_element_indices.index(param_array[1])]
+            if param_array[1] in param_array_element_indices:
+                param_element = param_array_elements[
+                    param_array_element_indices.index(param_array[1])
+                ]
         parent_element = param_element.parentNode
         parent_element.removeChild(param_element)
         param_element.unlink()
     return dom
 
+
 # Remove parameter
 def remove_var(dom, section_name, var_name):
-    if (section_name == 'make-arg'):
-        section_name = 'build'
-        path = ['make-arg']
+    if section_name == "make-arg":
+        section_name = "build"
+        path = ["make-arg"]
     else:
-        path = ['var']
-    element = extract_var_section_element(dom,section_name,False)
-    var_elements = select_elements(element,path)
-    var_element_names = get_attribute_values(var_elements,'name')
-    if (var_name in var_element_names):
+        path = ["var"]
+    element = extract_var_section_element(dom, section_name, False)
+    var_elements = select_elements(element, path)
+    var_element_names = get_attribute_values(var_elements, "name")
+    if var_name in var_element_names:
         var_element = var_elements[var_element_names.index(var_name)]
         parent_element = var_element.parentNode
         parent_element.removeChild(var_element)
         var_element.unlink()
     return dom
 
+
 # Extract parameter value or description either from a config document or the definition document
-def get_param(dom, component_name, param_name, definition=False, extract='value'):
-    element = extract_component_element(dom,component_name,definition)
-    if (not element):
+def get_param(dom, component_name, param_name, definition=False, extract="value"):
+    element = extract_component_element(dom, component_name, definition)
+    if not element:
         return False
     # Test if an element of a 'paramArray' has to be looked up and
     # look up parameter
     param_array = is_param_array(param_name)
-    if (param_array):
+    if param_array:
         param_name = param_array[0]
-        if (definition):
-            path = ['file','namelist','paramArray']
+        if definition:
+            path = ["file", "namelist", "paramArray"]
         else:
-            path = ['paramArray']
-        param_elements = select_elements(element,path)
+            path = ["paramArray"]
+        param_elements = select_elements(element, path)
     else:
-        if (definition):
-            path = ['file','namelist','param']
+        if definition:
+            path = ["file", "namelist", "param"]
         else:
-            path = ['param']
-        param_elements = select_elements(element,path)
-    param_element_names = get_attribute_values(param_elements,'name')
-    if (param_name in param_element_names):
+            path = ["param"]
+        param_elements = select_elements(element, path)
+    param_element_names = get_attribute_values(param_elements, "name")
+    if param_name in param_element_names:
         param_element = param_elements[param_element_names.index(param_name)]
     else:
         return False
     value = ""
-    if (param_array):
-        param_array_elements = select_elements(param_element,['param'])
-        param_array_element_indices = get_attribute_values(param_array_elements,'index')
+    if param_array:
+        param_array_elements = select_elements(param_element, ["param"])
+        param_array_element_indices = get_attribute_values(
+            param_array_elements, "index"
+        )
         # if selected, extract description or units from 'paramArray'
         # before proceeding to the selected element of the array
-        if (extract=='description'):
-            value_element = select_elements(param_element,['description'])
-            if (len(value_element)>0):
+        if extract == "description":
+            value_element = select_elements(param_element, ["description"])
+            if len(value_element) > 0:
                 value = extract_value(value_element[0])
-                if (len(value)>0):
-                    value = value+":\n"
-        elif (extract=='units'):
-            value_element = select_elements(param_element,['units'])
-            if (len(value_element)>0):
+                if len(value) > 0:
+                    value = value + ":\n"
+        elif extract == "units":
+            value_element = select_elements(param_element, ["units"])
+            if len(value_element) > 0:
                 value = extract_value(value_element[0])
-                if (len(value)>0):
-                    value = value+":\n"
+                if len(value) > 0:
+                    value = value + ":\n"
         # overwrite 'param_element' with selected element of
         #'paramArray'
-        if (param_array[1] in param_array_element_indices):
-            param_element = param_array_elements[param_array_element_indices.index(param_array[1])]
+        if param_array[1] in param_array_element_indices:
+            param_element = param_array_elements[
+                param_array_element_indices.index(param_array[1])
+            ]
         else:
             return False
     # Extract value
-    if ((definition) and (extract=='value')):
-        value_element = select_elements(param_element,['value'])
-        if (len(value_element) > 0):
+    if (definition) and (extract == "value"):
+        value_element = select_elements(param_element, ["value"])
+        if len(value_element) > 0:
             value_element = value_element[0]
         else:
             return False
-    elif (extract=='description'):
-        value_element = select_elements(param_element,['description'])
-        if (len(value_element) > 0):
+    elif extract == "description":
+        value_element = select_elements(param_element, ["description"])
+        if len(value_element) > 0:
             value_element = value_element[0]
         else:
             return False
-    elif (extract=='units'):
-        value_element = select_elements(param_element,['units'])
-        if (len(value_element) > 0):
+    elif extract == "units":
+        value_element = select_elements(param_element, ["units"])
+        if len(value_element) > 0:
             value_element = value_element[0]
         else:
             return False
     else:
         value_element = param_element
-    value = value+extract_value(value_element)
+    value = value + extract_value(value_element)
     return value
+
 
 # Extract parameter value from a config document
 def get_param_config_value(dom, component_name, param_name):
     return get_param(dom, component_name, param_name, definition=False)
 
+
 # Extract parameter value from the definition document
 def get_param_default_value(dom, component_name, param_name):
     return get_param(dom, component_name, param_name, definition=True)
 
+
 # Extract description for specified parameter from the config document
 def get_param_config_description(dom, component_name, param_name):
-    return get_param(dom, component_name, param_name, definition=False, extract='description')
+    return get_param(
+        dom, component_name, param_name, definition=False, extract="description"
+    )
+
 
 # Extract description for specified parameter from the definition document
 def get_param_default_description(dom, component_name, param_name):
-    return get_param(dom, component_name, param_name, definition=True, extract='description')
+    return get_param(
+        dom, component_name, param_name, definition=True, extract="description"
+    )
+
 
 # Extract units for specified parameter from the config document
 def get_param_config_units(dom, component_name, param_name):
-    return get_param(dom, component_name, param_name, definition=False, extract='units')
+    return get_param(dom, component_name, param_name, definition=False, extract="units")
+
 
 # Extract units for specified parameter from the definition document
 def get_param_default_units(dom, component_name, param_name):
-    return get_param(dom, component_name, param_name, definition=True, extract='units')
+    return get_param(dom, component_name, param_name, definition=True, extract="units")
+
 
 #################################################
 # Wrapper if 'GENIEconf.py' is called as a script
 #################################################
 if __name__ == "__main__":
     import sys
-# test for read command
-    definition_file = 'src/xml-config/xml/definition.xml'
+
+    # test for read command
+    definition_file = "src/xml-config/xml/definition.xml"
     dom_definition = get_dom(definition_file)
-    if (len(sys.argv) < 2):
-        print "Error: No command specified!"
+    if len(sys.argv) < 2:
+        print("Error: No command specified!")
         sys.exit(1)
     command = sys.argv[1]
-    if (len(sys.argv) < 3):
-        print "Error: No component/section specified!"
+    if len(sys.argv) < 3:
+        print("Error: No component/section specified!")
         sys.exit(1)
     component_name = sys.argv[2]
     section_name = component_name
-    if (len(sys.argv) < 4):
-        print "Error: No parameter name specified!"
+    if len(sys.argv) < 4:
+        print("Error: No parameter name specified!")
         sys.exit(1)
     name = sys.argv[3]
-    if (len(sys.argv) < 5):
+    if len(sys.argv) < 5:
         config_file = False
     else:
-        if (len(sys.argv) > 5):
+        if len(sys.argv) > 5:
             config_file = sys.argv[5]
             value = sys.argv[4]
         else:
             config_file = sys.argv[4]
         dom_config = get_dom(config_file)
-        if (not dom_config):
+        if not dom_config:
             implementation = xml.dom.minidom.getDOMImplementation()
-            dom_config = implementation.createDocument(None,"job",None)
-    if (command == 'get_param_config'):
-        if (not config_file):
+            dom_config = implementation.createDocument(None, "job", None)
+    if command == "get_param_config":
+        if not config_file:
             dom_definition.unlink()
             sys.exit(1)
-        result = get_param_config_value(dom_config,component_name,name)
-    elif (command == 'get_param_default'):
-        result = get_param_default_value(dom_definition,component_name,name)
-    elif (command == 'get_param'):
+        result = get_param_config_value(dom_config, component_name, name)
+    elif command == "get_param_default":
+        result = get_param_default_value(dom_definition, component_name, name)
+    elif command == "get_param":
         result = False
-        if (config_file):
-            result = get_param_config_value(dom_config,component_name,name)
-        if (not result):
-            result = get_param_default_value(dom_definition,component_name,name)
-    elif (command == 'get_param_config_description'):
-        if (not config_file):
+        if config_file:
+            result = get_param_config_value(dom_config, component_name, name)
+        if not result:
+            result = get_param_default_value(dom_definition, component_name, name)
+    elif command == "get_param_config_description":
+        if not config_file:
             dom_definition.unlink()
             sys.exit(1)
-        result = get_param_config_description(dom_config,component_name,name)
-    elif (command == 'get_param_default_description'):
-        result = get_param_default_description(dom_definition,component_name,name)
-    elif (command == 'get_param_description'):
+        result = get_param_config_description(dom_config, component_name, name)
+    elif command == "get_param_default_description":
+        result = get_param_default_description(dom_definition, component_name, name)
+    elif command == "get_param_description":
         result = False
-        if (config_file):
-            result = get_param_config_description(dom_config,component_name,name)
-        if (not result):
-            result = get_param_default_description(dom_definition,component_name,name)
-    elif (command == 'get_param_config_units'):
-        if (not config_file):
+        if config_file:
+            result = get_param_config_description(dom_config, component_name, name)
+        if not result:
+            result = get_param_default_description(dom_definition, component_name, name)
+    elif command == "get_param_config_units":
+        if not config_file:
             dom_definition.unlink()
             sys.exit(1)
-        result = get_param_config_value(dom_config,component_name,name)
-    elif (command == 'get_param_default_units'):
-        result = get_param_default_value(dom_definition,component_name,name)
-    elif (command == 'get_param_units'):
+        result = get_param_config_value(dom_config, component_name, name)
+    elif command == "get_param_default_units":
+        result = get_param_default_value(dom_definition, component_name, name)
+    elif command == "get_param_units":
         result = False
-        if (config_file):
-            result = get_param_config_units(dom_config,component_name,name)
-        if (not result):
-            result = get_param_default_units(dom_definition,component_name,name)
-    elif (command == 'insert_param'):
-        result = set_param(dom_config,dom_definition,component_name,name,value,False)
-        if (result):
+        if config_file:
+            result = get_param_config_units(dom_config, component_name, name)
+        if not result:
+            result = get_param_default_units(dom_definition, component_name, name)
+    elif command == "insert_param":
+        result = set_param(
+            dom_config, dom_definition, component_name, name, value, False
+        )
+        if result:
             result = result.toprettyxml()
-    elif (command == 'set_param'):
-        result = set_param(dom_config,dom_definition,component_name,name,value,True)
-        if (result):
+    elif command == "set_param":
+        result = set_param(
+            dom_config, dom_definition, component_name, name, value, True
+        )
+        if result:
             result = result.toprettyxml()
-    elif (command == 'get_var'):
+    elif command == "get_var":
         result = False
-        if (config_file):
-            result = get_var(dom_config,section_name,name,False)
-        if (not result):
-            result = get_var(dom_definition,section_name,name,True)
-    elif (command == 'set_var'):
-        result = set_var(dom_config,dom_definition,section_name,name,value,True)
-        if (result):
+        if config_file:
+            result = get_var(dom_config, section_name, name, False)
+        if not result:
+            result = get_var(dom_definition, section_name, name, True)
+    elif command == "set_var":
+        result = set_var(dom_config, dom_definition, section_name, name, value, True)
+        if result:
             result = result.toprettyxml()
     else:
-        print "Error: Command '%s' not available!" % sys.argv[1]
-        if (config_file):
+        print("Error: Command '%s' not available!" % sys.argv[1])
+        if config_file:
             dom_config.unlink()
         dom_definition.unlink()
         sys.exit(1)
-    if (result):
-        print result
-        if (config_file):
+    if result:
+        print(result)
+        if config_file:
             dom_config.unlink()
         dom_definition.unlink()
         sys.exit(0)
     else:
-        if (config_file):
+        if config_file:
             dom_config.unlink()
         dom_definition.unlink()
         sys.exit(1)

--- a/genie-main/config2xml.py
+++ b/genie-main/config2xml.py
@@ -12,7 +12,7 @@ varlist = ["EXPID","RESTARTREAD","CHECKFLUXES"]
 # GEM common is included in control section
 # initialise with default science module choices
 configflags = {
-    # flag name in control,shortname,defual config, prefix 
+    # flag name in control,shortname,defual config, prefix
     # atmos
     "ma_flag_ebatmos" : ["embm",".FALSE.","ea"],
     "ma_flag_goldsteinocean" : ["goldstein",".FALSE.","go"],
@@ -28,7 +28,7 @@ configflags = {
     "gl_flag_gemlite" : ["gemlite",".TRUE.","gl"],
     }
 
-control = {} 
+control = {}
 
 # paramarrays!
 # gem
@@ -857,12 +857,12 @@ configfile = {} # to hold data from config file
 
 # Parse command line--only one arg permitted
 if len(sys.argv) != 2:
-    print "usage: config2xml <config-file-name>"
+    print("usage: config2xml <config-file-name>")
     sys.exit(2)
 configname = sys.argv[1]
 # ensure that the arg is a genuine file
 if not os.path.isfile(configname):
-    print "error: could not find file %s" % configname
+    print("error: could not find file %s" % configname)
     sys.exit(1)
 
 # load genie-main/namelists.sh
@@ -925,7 +925,7 @@ for item in configfile:
     for var in testlist:
         if var == item:
             testing[item] = configfile[item]
-    
+
     # sort out the <control> and <config> sections
     if (item.startswith("ma_") or item.startswith("gem_") or item.startswith("gm_")):
         done=0
@@ -944,76 +944,76 @@ for item in configfile:
         if item in paramarray.keys():
             paramarray[item][1] = configfile[item]
             deletelist.append(item)
-            
+
 # must delete param array entries outside of loop
 for item in deletelist:
     del configfile[item]
 
-#print betaz
-#print deletelist
+#print(betaz)
+#print(deletelist)
 #sys.exit(0)
 
 # Let's start printing!
 # header
-print '<?xml version="1.0" encoding="UTF-8"?>'
-print '<job author="config2xml.py - automatic conversion of ASCII text config file">'
+print('<?xml version="1.0" encoding="UTF-8"?>')
+print('<job author="config2xml.py - automatic conversion of ASCII text config file">')
 # <vars> section
-print '\t<vars>'
+print('\t<vars>')
 for var in vars:
-    print '\t\t<var name="' + str(var) + '">' + str(vars[var]) + '</var>' 
-print '\t</vars>'
+    print('\t\t<var name="' + str(var) + '">' + str(vars[var]) + '</var>')
+print('\t</vars>')
 # <config> section
-print '\t<config>'
+print('\t<config>')
 for model in configflags:
     if (configflags[model][1] == ".TRUE." or configflags[model][1] == ".true."):
-        print '\t\t<model name="' + str(configflags[model][0]) + '"/>'
-print '\t</config>'
+        print('\t\t<model name="' + str(configflags[model][0]) + '"/>')
+print('\t</config>')
 # <parameters> section
-print '\t<parameters>'
+print('\t<parameters>')
 #    <control> subsection
-print '\t\t<control>'
+print('\t\t<control>')
 for entry in control:
     myval = control[entry]
     repval = pp.sub(r'<varref>\1</varref>/', myval)
-    print '\t\t\t<param name="' +str(namelists[entry]) + '">' + str(repval) +'</param>'
+    print('\t\t\t<param name="' +str(namelists[entry]) + '">' + str(repval) +'</param>')
         # --gem--
 vals = ""
 for list in atm_select.values():
     vals = vals + list[1]
 if vals:
-    print '\t\t\t<paramArray name="atm_select">'
+    print('\t\t\t<paramArray name="atm_select">')
     for key in atm_select.keys():
         if atm_select[key][1] != "":
-            print '\t\t\t\t<param index="'+str(atm_select[key][0])+'">'+str(atm_select[key][1])+'</param>'
-    print '\t\t\t</paramArray>'
+            print('\t\t\t\t<param index="'+str(atm_select[key][0])+'">'+str(atm_select[key][1])+'</param>')
+    print('\t\t\t</paramArray>')
 vals = ""
 for list in ocn_select.values():
     vals = vals + list[1]
 if vals:
-    print '\t\t\t<paramArray name="ocn_select">'
+    print('\t\t\t<paramArray name="ocn_select">')
     for key in ocn_select.keys():
         if ocn_select[key][1] != "":
-            print '\t\t\t\t<param index="'+str(ocn_select[key][0])+'">'+str(ocn_select[key][1])+'</param>'
-    print '\t\t\t</paramArray>'
+            print('\t\t\t\t<param index="'+str(ocn_select[key][0])+'">'+str(ocn_select[key][1])+'</param>'
+    print('\t\t\t</paramArray>')
 vals = ""
 for list in sed_select.values():
     vals = vals + list[1]
 if vals:
-    print '\t\t\t<paramArray name="sed_select">'
+    print('\t\t\t<paramArray name="sed_select">')
     for key in sed_select.keys():
         if sed_select[key][1] != "":
-            print '\t\t\t\t<param index="'+str(sed_select[key][0])+'">'+str(sed_select[key][1])+'</param>'
-    print '\t\t\t</paramArray>'
-print '\t\t</control>'
+            print('\t\t\t\t<param index="'+str(sed_select[key][0])+'">'+str(sed_select[key][1])+'</param>')
+    print('\t\t\t</paramArray>')
+print('\t\t</control>')
 for model in configflags:
     # only need output params for selected models..
     if (configflags[model][1] == ".TRUE." or configflags[model][1] == ".true."):
-        print '\t\t<model name="' + str(configflags[model][0]) + '">'
+        print('\t\t<model name="' + str(configflags[model][0]) + '">')
         for entry in configfile:
             if entry.startswith(configflags[model][2]+'_'):
                 myval = configfile[entry]
                 repval = pp.sub(r'<varref>\1</varref>/', myval)
-                print '\t\t\t<param name="' +str(namelists[entry]) + '">' + str(repval) +'</param>'
+                print('\t\t\t<param name="' +str(namelists[entry]) + '">' + str(repval) +'</param>')
         # plus paramarray specials
         # --atchem--
         if configflags[model][0] == "atchem":
@@ -1021,88 +1021,88 @@ for model in configflags:
             for list in atm_init.values():
                 vals = vals + list[1]
             if vals:
-                print '\t\t\t<paramArray name="atm_init">'
+                print('\t\t\t<paramArray name="atm_init">')
                 for key in atm_init.keys():
                     if atm_init[key][1] != "":
-                        print '\t\t\t\t<param index="'+str(atm_init[key][0])+'">'+str(atm_init[key][1])+'</param>'
-                print '\t\t\t</paramArray>'
+                        print('\t\t\t\t<param index="'+str(atm_init[key][0])+'">'+str(atm_init[key][1])+'</param>')
+                print('\t\t\t</paramArray>')
         # --biogem--
         if configflags[model][0] == "biogem":
             vals = ""
             for list in ocn_init.values():
                 vals = vals + list[1]
             if vals:
-                print '\t\t\t<paramArray name="ocn_init">'
+                print('\t\t\t<paramArray name="ocn_init">')
                 for key in ocn_init.keys():
                     if ocn_init[key][1] != "":
-                        print '\t\t\t\t<param index="'+str(ocn_init[key][0])+'">'+str(ocn_init[key][1])+'</param>'
-                print '\t\t\t</paramArray>'
+                        print('\t\t\t\t<param index="'+str(ocn_init[key][0])+'">'+str(ocn_init[key][1])+'</param>')
+                print('\t\t\t</paramArray>')
         # --embm--
         if configflags[model][0] == "embm":
             vals = ""
             for list in diffamp.values():
                 vals = vals + list[1]
             if vals:
-                print '\t\t\t<paramArray name="diffamp">'
+                print('\t\t\t<paramArray name="diffamp">')
                 for key in diffamp.keys():
                     if diffamp[key][1] != "":
-                        print '\t\t\t\t<param index="'+str(diffamp[key][0])+'">'+str(diffamp[key][1])+'</param>'
-                print '\t\t\t</paramArray>'
+                        print('\t\t\t\t<param index="'+str(diffamp[key][0])+'">'+str(diffamp[key][1])+'</param>')
+                print('\t\t\t</paramArray>')
             vals = ""
             for list in betaz.values():
                 vals = vals + list[1]
             if vals:
-                print '\t\t\t<paramArray name="betaz">'
+                print('\t\t\t<paramArray name="betaz">')
                 for key in betaz.keys():
                     if betaz[key][1] != "":
-                        print '\t\t\t\t<param index="'+str(betaz[key][0])+'">'+str(betaz[key][1])+'</param>'
-                print '\t\t\t</paramArray>'
+                        print('\t\t\t\t<param index="'+str(betaz[key][0])+'">'+str(betaz[key][1])+'</param>')
+                print('\t\t\t</paramArray>')
             vals = ""
             for list in betam.values():
                 vals = vals + list[1]
             if vals:
-                print '\t\t\t<paramArray name="betam">'
+                print('\t\t\t<paramArray name="betam">')
                 for key in betam.keys():
                     if betam[key][1] != "":
-                        print '\t\t\t\t<param index="'+str(betam[key][0])+'">'+str(betam[key][1])+'</param>'
-                print '\t\t\t</paramArray>'
-        # --goldstein--        
+                        print('\t\t\t\t<param index="'+str(betam[key][0])+'">'+str(betam[key][1])+'</param>')
+                print('\t\t\t</paramArray>')
+        # --goldstein--
         if configflags[model][0] == "goldstein":
             vals = ""
             for list in diff.values():
                 vals = vals + list[1]
             if vals:
-                print '\t\t\t<paramArray name="diff">'
+                print('\t\t\t<paramArray name="diff">')
                 for key in diff.keys():
                     if diff[key][1] != "":
-                        print '\t\t\t\t<param index="'+str(diff[key][0])+'">'+str(diff[key][1])+'</param>'
-                print '\t\t\t</paramArray>'
-        print '\t\t</model>'
-print '\t</parameters>'
+                        print('\t\t\t\t<param index="'+str(diff[key][0])+'">'+str(diff[key][1])+'</param>')
+                print('\t\t\t</paramArray>')
+        print('\t\t</model>')
+print('\t</parameters>')
 # <build> section
-print '\t<build>'
+print('\t<build>')
 # make args first
 for arg in makeargs:
-    print '\t\t<make-arg name="'+str(arg)+'">'+str(makeargs[arg])+'</make-arg>'
+    print('\t\t<make-arg name="'+str(arg)+'">'+str(makeargs[arg])+'</make-arg>')
 # then macros
 for macro in macros:
-    print '\t\t<macro handle="'+str(macro)+'" status="defined">'
+    print('\t\t<macro handle="'+str(macro)+'" status="defined">')
     myval = macros[macro]
     myval = myval.replace('$(DEFINE)','')
     myval = myval.replace("'","")
     # may not contain an '='
     splitret = myval.split('=')
     ident = splitret[0]
-    print '\t\t\t<identifier>'+str(ident)+'</identifier>'
+    print('\t\t\t<identifier>'+str(ident)+'</identifier>')
     if len(splitret) > 1:
         repl = splitret[1]
-        print '\t\t\t<replacement>'+str(repl)+'</replacement>'
-    print '\t\t</macro>'
-print '\t</build>'
+        print('\t\t\t<replacement>'+str(repl)+'</replacement>')
+    print('\t\t</macro>')
+print('\t</build>')
 # <testing> section
-print '\t<testing>'
+print('\t<testing>')
 for var in testing:
     if testing[var] != "${EXPID}_assumedgood":
-        print '\t\t<var name="'+str(var)+'">'+str(testing[var])+'</var>'
-print '\t</testing>'
-print '</job>'
+        print('\t\t<var name="'+str(var)+'">'+str(testing[var])+'</var>')
+print('\t</testing>')
+print('</job>')

--- a/genie-main/finc.py
+++ b/genie-main/finc.py
@@ -1,47 +1,51 @@
 #!/usr/bin/python
 
-#$Id$
+# $Id$
 
 import sys
 import os.path
 import re
 
-valid_ext_list = ['.f','.F','.f90']
+valid_ext_list = [".f", ".F", ".f90"]
+
 
 def find_includes(filename):
-    '''returns a list of included files found in some Fortran source
+    """returns a list of included files found in some Fortran source
 
     opens the given file, scans each line using a regular expression,
-    appends to a list of included files if required, closes the file.'''
+    appends to a list of included files if required, closes the file."""
 
     # list of files (common blocks etc.) 'included' in source
     filelist = []
-    
-    f = open(filename)                 # open the filehandle
+
+    f = open(filename)  # open the filehandle
     while 1:
-        line = f.readline()            # read the next line
-        if not line: break             # break loop on EOF
-        line = line.strip()            # strip '\n'
-        if line == '': continue        # ignore blank lines
-        
+        line = f.readline()  # read the next line
+        if not line:
+            break  # break loop on EOF
+        line = line.strip()  # strip '\n'
+        if line == "":
+            continue  # ignore blank lines
+
         # match lines we're interested in with a regular expression
         # first compile the regexp
-        p = re.compile(r'#?include\s*[\'\"](\w*\.\w*)[\'\"]', re.IGNORECASE)
+        p = re.compile(r"#?include\s*[\'\"](\w*\.\w*)[\'\"]", re.IGNORECASE)
         # now try to match
         m = p.match(line)
         # if there is a match
         if m:
-            file = m.group(1)         # the included filename 
+            file = m.group(1)  # the included filename
             if file not in filelist:  # test for duplicates
-                filelist.append(file) # add to list if not
-                
-    f.close()                         # close the filehandle
-    filelist.sort()                   # sort the list
-    return filelist                   # and return it
+                filelist.append(file)  # add to list if not
+
+    f.close()  # close the filehandle
+    filelist.sort()  # sort the list
+    return filelist  # and return it
+
 
 # if being called as a script
-if __name__ == '__main__':
-    '''print a makefile dependency line for some fortran source'''
+if __name__ == "__main__":
+    """print a makefile dependency line for some fortran source"""
 
     # only one command line arg permitted
     if len(sys.argv) != 2:
@@ -63,9 +67,9 @@ if __name__ == '__main__':
         include_list = find_includes(filename)
         # print the makefile line
         # e.g. "myfile.o : myfile.f inc1.cmn inc2.cmn"
-        return_string = base + '.o : ' + tail + ' '
+        return_string = base + ".o : " + tail + " "
         for inc in include_list:
-            return_string += inc + ' '
-        print return_string
+            return_string += inc + " "
+        print(return_string)
         # and exit
         sys.exit(0)

--- a/genie-main/nccomp.py
+++ b/genie-main/nccomp.py
@@ -2,7 +2,7 @@
 #
 # $Id$
 #
-'''A program to compare two NetCDF files.'''
+"""A program to compare two NetCDF files."""
 
 import sys
 import types
@@ -12,37 +12,38 @@ import cdms
 import MV
 
 # define useful globals
-TRUE,FALSE=1,0
+TRUE, FALSE = 1, 0
+
 
 def simpleComp(fileA, fileB, tol=0.0):
-    '''A simple comparison function.
+    """A simple comparison function.
 
        Attribute names and values are compared first.
        Then the data arrays are compared within a
-       tolerance on a cell by cell basis.'''
-    
+       tolerance on a cell by cell basis."""
+
     # open files
     fpA = cdms.open(fileA)
     fpB = cdms.open(fileB)
 
     # == global attributes ==
     # compare attribute names
-    message = 'global attributes: '
+    message = "global attributes: "
     globalNamesA = Set(fpA.listglobal())
     globalNamesB = Set(fpB.listglobal())
     symmetricDiff = globalNamesA ^ globalNamesB
     if len(symmetricDiff) != 0:
-        (detailA, detailB) = setDiff(globalNamesA,globalNamesB,symmetricDiff)
-        return (FALSE,message,detailA,detailB)
+        (detailA, detailB) = setDiff(globalNamesA, globalNamesB, symmetricDiff)
+        return (FALSE, message, detailA, detailB)
     # compare values
     for globalName in globalNamesA:
         # limit our checks to attributes with string values
-        if isinstance(eval(r'fpA.'+globalName),types.StringType):
-            globalValueA = eval(r'fpA.'+globalName)
-            globalValueB = eval(r'fpB.'+globalName)
+        if isinstance(eval(r"fpA." + globalName), types.StringType):
+            globalValueA = eval(r"fpA." + globalName)
+            globalValueB = eval(r"fpB." + globalName)
             if globalValueA != globalValueB:
-                message += globalName + ' values'
-                return(FALSE,message,globalValueA,globalValueB)
+                message += globalName + " values"
+                return (FALSE, message, globalValueA, globalValueB)
 
     # == dimensions ==
     # compare dimension names
@@ -50,37 +51,37 @@ def simpleComp(fileA, fileB, tol=0.0):
     dimNamesB = Set(fpB.listdimension())
     symmetricDiff = dimNamesA ^ dimNamesB
     if len(symmetricDiff) != 0:
-        message = 'dimensions:'
-        (detailA, detailB) = setDiff(dimNamesA,dimNamesB,symmetricDiff)
-        return (FALSE,message,detailA,detailB)
+        message = "dimensions:"
+        (detailA, detailB) = setDiff(dimNamesA, dimNamesB, symmetricDiff)
+        return (FALSE, message, detailA, detailB)
     # loop over dimensions
     for dimName in dimNamesA:
-        message = 'dimensions: '+ dimName
+        message = "dimensions: " + dimName
         # compare attribute names
         dimAttNamesA = Set(fpA[dimName].attributes.keys())
         dimAttNamesB = Set(fpA[dimName].attributes.keys())
         symmetricDiff = dimAttNamesA ^ dimAttNamesB
         if len(symmetricDiff) != 0:
-            (detailA, detailB) = setDiff(dimAttNamesA,dimAttNamesB,symmetricDiff)
-            return (FALSE,message,detailA,detailB)
+            (detailA, detailB) = setDiff(dimAttNamesA, dimAttNamesB, symmetricDiff)
+            return (FALSE, message, detailA, detailB)
         # compare attribute values
         for dimAttName in dimAttNamesA:
             # assuming objects we can compare
-            dimAttValueA = eval(r"fpA['"+dimName+r"']."+dimAttName)
-            dimAttValueB = eval(r"fpB['"+dimName+r"']."+dimAttName)
+            dimAttValueA = eval(r"fpA['" + dimName + r"']." + dimAttName)
+            dimAttValueB = eval(r"fpB['" + dimName + r"']." + dimAttName)
             if dimAttValueA != dimAttValueB:
-                message += ': '+dimAttName
-                return (FALSE,message,dimAttValueA,dimAttValueB)
+                message += ": " + dimAttName
+                return (FALSE, message, dimAttValueA, dimAttValueB)
         # compare data
         dimDataShapeA = MV.shape(fpA[dimName])
         dimDataShapeB = MV.shape(fpB[dimName])
         if dimDataShapeA != dimDataShapeB:
-            message += ': data array shape'
-            return (FALSE,message,str(dimDataShapeA),str(dimDataShapeB))
+            message += ": data array shape"
+            return (FALSE, message, str(dimDataShapeA), str(dimDataShapeB))
         maxDelta = MV.maximum(abs(fpA[dimName][:] - fpB[dimName][:]))
         if maxDelta > tol:
-            message += ': delta: '+str(maxDelta)+' > '+str(tol)
-            return (FALSE,message,'','')
+            message += ": delta: " + str(maxDelta) + " > " + str(tol)
+            return (FALSE, message, "", "")
 
     # == variables ==
     # compare variable names
@@ -88,55 +89,57 @@ def simpleComp(fileA, fileB, tol=0.0):
     varNamesB = Set(fpB.listvariables())
     symmetricDiff = varNamesA ^ varNamesB
     if len(symmetricDiff) != 0:
-        message = 'variables:'
-        (detailA, detailB) = setDiff(varNamesA,varNamesB,symmetricDiff)
-        return (FALSE,message,detailA,detailB)
+        message = "variables:"
+        (detailA, detailB) = setDiff(varNamesA, varNamesB, symmetricDiff)
+        return (FALSE, message, detailA, detailB)
     # loop over variables
     for varName in varNamesA:
-        message = 'variables: '+varName
+        message = "variables: " + varName
         # compare attribute names
         varAttNamesA = Set(fpA[varName].attributes.keys())
         varAttNamesB = Set(fpA[varName].attributes.keys())
         symmetricDiff = varAttNamesA ^ varAttNamesB
         if len(symmetricDiff) != 0:
-            (detailA, detailB) = setDiff(varAttNamesA,varAttNamesB,symmetricDiff)
-            return (FALSE,message,detailA,detailB)
+            (detailA, detailB) = setDiff(varAttNamesA, varAttNamesB, symmetricDiff)
+            return (FALSE, message, detailA, detailB)
         # compare attribute values
         for varAttName in varAttNamesA:
             # assuming objects we can compare
-            varAttValueA = eval(r"fpA['"+varName+r"']."+varAttName)
-            varAttValueB = eval(r"fpB['"+varName+r"']."+varAttName)
+            varAttValueA = eval(r"fpA['" + varName + r"']." + varAttName)
+            varAttValueB = eval(r"fpB['" + varName + r"']." + varAttName)
             if varAttValueA != varAttValueB:
-                message += ': '+varAttName
-                return (FALSE,message,varAttValueA,varAttValueB)
+                message += ": " + varAttName
+                return (FALSE, message, varAttValueA, varAttValueB)
         # compare data
         varDataShapeA = MV.shape(fpA[varName])
         varDataShapeB = MV.shape(fpB[varName])
         if varDataShapeA != varDataShapeB:
-            message += ': data array shape'
-            return (FALSE,message,str(varDataShapeA),str(varDataShapeB))
+            message += ": data array shape"
+            return (FALSE, message, str(varDataShapeA), str(varDataShapeB))
         maxDelta = MV.maximum(abs(fpA[varName][:] - fpB[varName][:]))
         if maxDelta > tol:
-            message += ': delta: '+str(maxDelta)+' > '+str(tol)
-            return (FALSE,message,'','')
+            message += ": delta: " + str(maxDelta) + " > " + str(tol)
+            return (FALSE, message, "", "")
 
     # close files
     fpA.close()
     fpB.close()
-    return (TRUE,'','','')
+    return (TRUE, "", "", "")
+
 
 def setDiff(setA, setB, symmetricDiff):
     detailA = setA & symmetricDiff
     detailB = setB & symmetricDiff
-    return (detailA,detailB)
+    return (detailA, detailB)
+
 
 def compVarSlice(fileA, fileB, var, dim, tol=0.0, start=0, end=0):
-    '''Compare a slice (of given dimension) through named variable'''
+    """Compare a slice (of given dimension) through named variable"""
 
     # open files
     fpA = cdms.open(fileA)
     fpB = cdms.open(fileB)
-    
+
     # check named variable present in both files
     varsA = Set(fpA.listvariables())
     varsB = Set(fpB.listvariables())
@@ -144,7 +147,7 @@ def compVarSlice(fileA, fileB, var, dim, tol=0.0, start=0, end=0):
     if var not in commonVars:
         fpA.close()
         fpB.close()
-        return (FALSE,var+' not common',varsA,varsB)
+        return (FALSE, var + " not common", varsA, varsB)
 
     # ditto for named dimension
     dimsA = Set(fpA.listdimension())
@@ -153,11 +156,15 @@ def compVarSlice(fileA, fileB, var, dim, tol=0.0, start=0, end=0):
     if dim not in commonDims:
         fpA.close()
         fpB.close()
-        return (FALSE,dim+' not common',dimsA,dimsB)
+        return (FALSE, dim + " not common", dimsA, dimsB)
 
     # get the slices
-    sliceA = eval(r"fpA('"+var+"',"+dim+"=slice("+str(start)+","+str(end)+"))")
-    sliceB = eval(r"fpB('"+var+"',"+dim+"=slice("+str(start)+","+str(end)+"))")
+    sliceA = eval(
+        r"fpA('" + var + "'," + dim + "=slice(" + str(start) + "," + str(end) + "))"
+    )
+    sliceB = eval(
+        r"fpB('" + var + "'," + dim + "=slice(" + str(start) + "," + str(end) + "))"
+    )
 
     # close files
     fpA.close()
@@ -165,29 +172,30 @@ def compVarSlice(fileA, fileB, var, dim, tol=0.0, start=0, end=0):
 
     # ensure dimensions of slices correct
     if sliceA.shape != sliceB.shape:
-        return (FALSE,'different shapes',sliceA.shape,sliceB.shape)
+        return (FALSE, "different shapes", sliceA.shape, sliceB.shape)
     if sliceA.shape[0] != end - start:
-        return (FALSE,'slice size wrong',str(sliceA.shape[0]),str(end-start))
+        return (FALSE, "slice size wrong", str(sliceA.shape[0]), str(end - start))
     if sliceA.shape[0] == 0:
-        return (FALSE,'slice size zero',str(sliceA.shape[0]),str(end-start))
+        return (FALSE, "slice size zero", str(sliceA.shape[0]), str(end - start))
 
     # make actual comparison
     maxDelta = MV.maximum(abs(sliceA - sliceB))
     if maxDelta > tol:
-        return (FALSE,'max diff > '+str(tol),'','')
+        return (FALSE, "max diff > " + str(tol), "", "")
     else:
-        return (TRUE,'','','')
+        return (TRUE, "", "", "")
 
     # could take difference of the averages too
-    
-if __name__ == '__main__':
+
+
+if __name__ == "__main__":
 
     tol = 0.0
-    
+
     # parse command line
     numArgs = len(sys.argv)
     if numArgs < 3 or numArgs > 4:
-        print 'usage: fileA.nc fileB.nc tol'
+        print("usage: fileA.nc fileB.nc tol")
         sys.exit(1)
     fileA = sys.argv[1]
     fileB = sys.argv[2]
@@ -196,20 +204,19 @@ if __name__ == '__main__':
 
     # make sure files exist!
     if not os.path.isfile(fileA):
-        print "does not exist: %s" % fileA
+        print("does not exist: %s" % fileA)
         sys.exit(1)
     if not os.path.isfile(fileB):
-        print "does not exist: %s" % fileB
+        print("does not exist: %s" % fileB)
         sys.exit(1)
 
     # make the comparison
-    (status,message,detailA,detailB) = simpleComp(fileA,fileB,tol)
+    (status, message, detailA, detailB) = simpleComp(fileA, fileB, tol)
 
     # report
     if status == FALSE:
-        print "files differ."
-        print "%s" % message
-        print "fileA: %s" % detailA
-        print "fileB: %s" % detailB
+        print("files differ.")
+        print("%s" % message)
+        print("fileA: %s" % detailA)
+        print("fileB: %s" % detailB)
         sys.exit(1)
-

--- a/genie-main/translate_config.py
+++ b/genie-main/translate_config.py
@@ -1,6 +1,7 @@
 #! /usr/bin/python
 
-def translate_config(config_filename,script_name='translate_config.py'):
+
+def translate_config(config_filename, script_name="translate_config.py"):
     #
     # Overview of inner workings of the script:
     # =========================================
@@ -28,7 +29,7 @@ def translate_config(config_filename,script_name='translate_config.py'):
     #
     # iii) write translated configuration
     #
-    
+
     # Extract parameters from 'definition.xml' for various sections or
     # subsets and use translations to filter parameters from old-style
     # configuration for the individual sections
@@ -87,7 +88,7 @@ def translate_config(config_filename,script_name='translate_config.py'):
     #           -> n
     #      translation: if in list of exceptions replace accordingly,
     #                  otherwise construct <prefix>_<var><array_convention>n
-    
+
     # Translation rules:
     # ==================
     #
@@ -136,8 +137,8 @@ def translate_config(config_filename,script_name='translate_config.py'):
     #     yv_wstress->ea_tauy_v
     #     u_wspeed->ea_adv_u
     #     v_wspeed->ea_adv_v
-    #     npstp->ea_3, 
-    #     iwstp->ea_4, 
+    #     npstp->ea_3,
+    #     iwstp->ea_4,
     #     itstp->ea_5
     #     ianav->ea_6
     #     ans->ea_7
@@ -200,20 +201,20 @@ def translate_config(config_filename,script_name='translate_config.py'):
     #     temp0->go_10
     #     temp1->go_11
     #     rel->go_12
-    #     scf->go_13,                 
+    #     scf->go_13,
     #     diff(1)->go_14
-    #     diff(2)->go_15,                               
+    #     diff(2)->go_15,
     #     adrag->go_16
     #     fwanomin->go_fwanom
-    #     cmip_model->go_fwanomfile,                              
-    #     albocn->go_albedo,                               
+    #     cmip_model->go_fwanomfile,
+    #     albocn->go_albedo,
     #     iconv->go_ocnconv
     #     tdatafile->go_Tdata
     #     sdatafile->go_Sdata
-    #     lout->go_17,                                      
-    #     netin->go_18,                                      
-    #     netout->go_19,                                      
-    #     ascout->go_20,                                      
+    #     lout->go_17,
+    #     netin->go_18,
+    #     netout->go_19,
+    #     ascout->go_20,
     #     filenetin->go_21
     #     dirnetout->go_22
     #     lin->go_23
@@ -257,138 +258,161 @@ def translate_config(config_filename,script_name='translate_config.py'):
     #     ents_dirnetout->ents_22
     #     ents_restart_file->ents_24
     #     ents_offlineswitch->ents_25
-    
-    prefixes = {'genie' : 'ma', 'embm' : 'ea', 'goldstein' : 'go', 'goldsteinseaice' : 'gs', 'plasim' : 'pl', 'ents' : 'el', 'GEM' : 'gm', 'biogem' : 'bg', 'ecogem' : 'eg', 'atchem' : 'ac', 'sedgem' : 'sg', 'rokgem' : 'rg', 'wind' : 'wi', 'gemlite' : 'gl', 'goldlite' : 'gi'}
-    array_conventions = {'gm': '_',
-                         'bg': '_',
-                         'eg': '_',
-                         'ac': '_'}
-    exceptions_ea = {'indir_name': 'ea_1',
-                     'outdir_name': 'ea_2',
-                     'igrid': 'ea_grid',
-                     'world': 'ea_topo',
-                     'xu_wstress': 'ea_taux_u',
-                     'yu_wstress': 'ea_tauy_u',
-                     'xv_wstress': 'ea_taux_v',
-                     'yv_wstress': 'ea_tauy_v',
-                     'u_wspeed': 'ea_adv_u',
-                     'v_wspeed': 'ea_adv_v',
-                     'npstp': 'ea_3',
-                     'iwstp': 'ea_4',
-                     'itstp': 'ea_5',
-                     'ianav': 'ea_6',
-                     'ans': 'ea_7',
-                     'yearlen': 'ea_8',
-                     'nyear': 'ea_9',
-                     'ndta': 'ea_10',
-                     'scf': 'ea_11',
-                     'diffamp(1)': 'ea_12',
-                     'diffamp(2)': 'ea_13',
-                     'diffwid': 'ea_14',
-                     'difflin': 'ea_15',
-                     'betaz(1)': 'ea_16',
-                     'betaz(2)': 'ea_18',
-                     'betam(1)': 'ea_17',
-                     'betam(2)': 'ea_19',
-                     'tatm': 'ea_22',
-                     'relh0_ocean': 'ea_23',
-                     'relh0_land': 'ea_24',
-                     'extra1a': 'ea_25',
-                     'extra1b': 'ea_26',
-                     'extra1c': 'ea_27',
-                     'scl_fwf': 'ea_28',
-                     'tdatafile': 'ea_Tdata',
-                     'qdatafile': 'ea_Hdata',
-                     'lout': 'ea_29',
-                     'netin': 'ea_30',
-                     'netout': 'ea_31',
-                     'ascout': 'ea_32',
-                     'filenetin': 'ea_33',
-                     'dirnetout': 'ea_34',
-                     'lin': 'ea_35',
-                     'atchem_radfor': 'ea_36',
-                     'olr_adj0': 'olr_adj0',
-                     'ents_radfor': 'ea_37',
-                     'orbit_radfor': 'ea_38',
-                     't_orbit': 'ea_39',
-                     'norbit': 'ea_40',
-                     'orbitsteps': 'ea_41',
-                     'filenameorbit': 'ea_42'}
-    exceptions_go = {'indir_name': 'go_1',
-                     'outdir_name': 'go_2',
-                     'igrid': 'go_grid',
-                     'world': 'go_topo',
-                     'npstp': 'go_3',
-                     'iwstp': 'go_4',
-                     'itstp': 'go_5',
-                     'ianav': 'go_6',
-                     'conserv_per': 'go_6b',
-                     'ans': 'go_7',
-                     'yearlen': 'go_8',
-                     'nyear': 'go_9',
-                     'temp0': 'go_10',
-                     'temp1': 'go_11',
-                     'rel': 'go_12',
-                     'scf': 'go_13',
-                     'diff(1)': 'go_14',
-                     'diff(2)': 'go_15',
-                     'adrag': 'go_16',
-                     'fwanomin': 'go_fwanom',
-                     'cmip_model': 'go_fwanomfile',
-                     'albocn': 'go_albedo',
-                     'iconv': 'go_ocnconv',
-                     'tdatafile': 'go_Tdata',
-                     'sdatafile': 'go_Sdata',
-                     'lout': 'go_17',
-                     'netin': 'go_18',
-                     'netout': 'go_19',
-                     'ascout': 'go_20',
-                     'filenetin': 'go_21',
-                     'dirnetout': 'go_22',
-                     'lin': 'go_23'}
-    exceptions_gs = {'indir_name': 'gs_1',
-                     'outdir_name': 'gs_2',
-                     'igrid': 'gs_grid',
-                     'world': 'gs_topo',
-                     'npstp': 'gs_3',
-                     'iwstp': 'gs_4',
-                     'itstp': 'gs_5',
-                     'ianav': 'gs_6',
-                     'conserv_per': 'gs_6b',
-                     'ans': 'gs_7',
-                     'yearlen': 'gs_8',
-                     'nyear': 'gs_9',
-                     'diffsic': 'gs_11',
-                     'lout': 'gs_12',
-                     'netin': 'gs_13',
-                     'netout': 'gs_14',
-                     'ascout': 'gs_15',
-                     'filenetin': 'gs_16',
-                     'dirnetout': 'gs_17',
-                     'lin': 'gs_18'}
-    exceptions_el = {'indir_name': 'el_1',
-                       'outdir_name': 'el_2',
-                       'condir_name': 'el_config',
-                       'ents_igrid': 'el_grid',
-                       'ents_npstp': 'el_3',
-                       'ents_iwstp': 'el_4',
-                       'ents_itstp': 'el_5',
-                       'ents_ianav': 'el_6',
-                       'ents_restart': 'el_7',
-                       'ents_yearlen': 'el_8',
-                       'ents_out_name': 'el_17',
-                       'ents_netin': 'el_18',
-                       'ents_netout': 'el_19',
-                       'ents_ascout': 'el_20',
-                       'ents_filenetin': 'el_21',
-                       'ents_dirnetout': 'el_22',
-                       'ents_restart_file': 'el_24',
-                       'ents_offlineswitch': 'el_25'}
-    exceptions = { 'ea': exceptions_ea,
-                   'go': exceptions_go,
-                   'gs': exceptions_gs,
-                   'el': exceptions_el }
-    
+
+    prefixes = {
+        "genie": "ma",
+        "embm": "ea",
+        "goldstein": "go",
+        "goldsteinseaice": "gs",
+        "plasim": "pl",
+        "ents": "el",
+        "GEM": "gm",
+        "biogem": "bg",
+        "ecogem": "eg",
+        "atchem": "ac",
+        "sedgem": "sg",
+        "rokgem": "rg",
+        "wind": "wi",
+        "gemlite": "gl",
+        "goldlite": "gi",
+    }
+    array_conventions = {"gm": "_", "bg": "_", "eg": "_", "ac": "_"}
+    exceptions_ea = {
+        "indir_name": "ea_1",
+        "outdir_name": "ea_2",
+        "igrid": "ea_grid",
+        "world": "ea_topo",
+        "xu_wstress": "ea_taux_u",
+        "yu_wstress": "ea_tauy_u",
+        "xv_wstress": "ea_taux_v",
+        "yv_wstress": "ea_tauy_v",
+        "u_wspeed": "ea_adv_u",
+        "v_wspeed": "ea_adv_v",
+        "npstp": "ea_3",
+        "iwstp": "ea_4",
+        "itstp": "ea_5",
+        "ianav": "ea_6",
+        "ans": "ea_7",
+        "yearlen": "ea_8",
+        "nyear": "ea_9",
+        "ndta": "ea_10",
+        "scf": "ea_11",
+        "diffamp(1)": "ea_12",
+        "diffamp(2)": "ea_13",
+        "diffwid": "ea_14",
+        "difflin": "ea_15",
+        "betaz(1)": "ea_16",
+        "betaz(2)": "ea_18",
+        "betam(1)": "ea_17",
+        "betam(2)": "ea_19",
+        "tatm": "ea_22",
+        "relh0_ocean": "ea_23",
+        "relh0_land": "ea_24",
+        "extra1a": "ea_25",
+        "extra1b": "ea_26",
+        "extra1c": "ea_27",
+        "scl_fwf": "ea_28",
+        "tdatafile": "ea_Tdata",
+        "qdatafile": "ea_Hdata",
+        "lout": "ea_29",
+        "netin": "ea_30",
+        "netout": "ea_31",
+        "ascout": "ea_32",
+        "filenetin": "ea_33",
+        "dirnetout": "ea_34",
+        "lin": "ea_35",
+        "atchem_radfor": "ea_36",
+        "olr_adj0": "olr_adj0",
+        "ents_radfor": "ea_37",
+        "orbit_radfor": "ea_38",
+        "t_orbit": "ea_39",
+        "norbit": "ea_40",
+        "orbitsteps": "ea_41",
+        "filenameorbit": "ea_42",
+    }
+    exceptions_go = {
+        "indir_name": "go_1",
+        "outdir_name": "go_2",
+        "igrid": "go_grid",
+        "world": "go_topo",
+        "npstp": "go_3",
+        "iwstp": "go_4",
+        "itstp": "go_5",
+        "ianav": "go_6",
+        "conserv_per": "go_6b",
+        "ans": "go_7",
+        "yearlen": "go_8",
+        "nyear": "go_9",
+        "temp0": "go_10",
+        "temp1": "go_11",
+        "rel": "go_12",
+        "scf": "go_13",
+        "diff(1)": "go_14",
+        "diff(2)": "go_15",
+        "adrag": "go_16",
+        "fwanomin": "go_fwanom",
+        "cmip_model": "go_fwanomfile",
+        "albocn": "go_albedo",
+        "iconv": "go_ocnconv",
+        "tdatafile": "go_Tdata",
+        "sdatafile": "go_Sdata",
+        "lout": "go_17",
+        "netin": "go_18",
+        "netout": "go_19",
+        "ascout": "go_20",
+        "filenetin": "go_21",
+        "dirnetout": "go_22",
+        "lin": "go_23",
+    }
+    exceptions_gs = {
+        "indir_name": "gs_1",
+        "outdir_name": "gs_2",
+        "igrid": "gs_grid",
+        "world": "gs_topo",
+        "npstp": "gs_3",
+        "iwstp": "gs_4",
+        "itstp": "gs_5",
+        "ianav": "gs_6",
+        "conserv_per": "gs_6b",
+        "ans": "gs_7",
+        "yearlen": "gs_8",
+        "nyear": "gs_9",
+        "diffsic": "gs_11",
+        "lout": "gs_12",
+        "netin": "gs_13",
+        "netout": "gs_14",
+        "ascout": "gs_15",
+        "filenetin": "gs_16",
+        "dirnetout": "gs_17",
+        "lin": "gs_18",
+    }
+    exceptions_el = {
+        "indir_name": "el_1",
+        "outdir_name": "el_2",
+        "condir_name": "el_config",
+        "ents_igrid": "el_grid",
+        "ents_npstp": "el_3",
+        "ents_iwstp": "el_4",
+        "ents_itstp": "el_5",
+        "ents_ianav": "el_6",
+        "ents_restart": "el_7",
+        "ents_yearlen": "el_8",
+        "ents_out_name": "el_17",
+        "ents_netin": "el_18",
+        "ents_netout": "el_19",
+        "ents_ascout": "el_20",
+        "ents_filenetin": "el_21",
+        "ents_dirnetout": "el_22",
+        "ents_restart_file": "el_24",
+        "ents_offlineswitch": "el_25",
+    }
+    exceptions = {
+        "ea": exceptions_ea,
+        "go": exceptions_go,
+        "gs": exceptions_gs,
+        "el": exceptions_el,
+    }
+
     # Parse old-style parameters from configuration file:
     #    - parse lines of format \s*<variable_name>\s*=\s*<value>.*,
     #                            \s*<variable_name>\s*=\s*'<value>'.*, or
@@ -408,28 +432,28 @@ def translate_config(config_filename,script_name='translate_config.py'):
     import sys
     import os.path
     import re
-    
+
     # ensure that the arg is a genuine file
     if not os.path.isfile(config_filename):
-        print "Error: File %s not found!" % configname
+        print("Error: File %s not found!" % configname)
         sys.exit(1)
     else:
-        re_key_val_1 = re.compile(r'^\s*([^\s\'\"]+?)\s*=\s*\'([^\']*)\'')
-        re_key_val_2 = re.compile(r'^\s*([^\s\'\"]+?)\s*=\s*\"([^\"]*)\"')
-        re_key_val_3 = re.compile(r'^\s*([^\s\'\"]+?)\s*=\s*([^\'\"\s\#]*)')
-    # set default model configuration implicitely used in the old
-    # configuration scheme
+        re_key_val_1 = re.compile(r"^\s*([^\s\'\"]+?)\s*=\s*\'([^\']*)\'")
+        re_key_val_2 = re.compile(r"^\s*([^\s\'\"]+?)\s*=\s*\"([^\"]*)\"")
+        re_key_val_3 = re.compile(r"^\s*([^\s\'\"]+?)\s*=\s*([^\'\"\s\#]*)")
+        # set default model configuration implicitely used in the old
+        # configuration scheme
         old_config = {}
         config_file = open(config_filename)
         while 1:
             line = config_file.readline()
             if not line:
                 break
-    # remove newlines
+            # remove newlines
             line = line.strip()
-    # remove comment (includes lines starting with '#' and 'echo') and
-    # empty lines
-            if line.startswith('#') or line.startswith('echo') or (line == ''):
+            # remove comment (includes lines starting with '#' and 'echo') and
+            # empty lines
+            if line.startswith("#") or line.startswith("echo") or (line == ""):
                 continue
             key_val = re_key_val_1.match(line)
             if key_val is None:
@@ -439,36 +463,36 @@ def translate_config(config_filename,script_name='translate_config.py'):
                     if key_val is None:
                         continue
             key, val = key_val.group(1), key_val.group(2)
-    # remove '$(DEFINE)'
-            val = val.replace('$(DEFINE)','')
-    # create dictionary from key-value pairs
+            # remove '$(DEFINE)'
+            val = val.replace("$(DEFINE)", "")
+            # create dictionary from key-value pairs
             old_config[key] = val
         config_file.close()
 
     # Read 'definition.xml' and extract parameters for various sections or
     # subsets
     # ====================================================================
-    
+
     # Use DOM approach to extract parameters
     import xml.dom.minidom
-    
-    dom_definition = xml.dom.minidom.parse('./src/xml-config/xml/definition.xml')
-    
+
+    dom_definition = xml.dom.minidom.parse("./src/xml-config/xml/definition.xml")
+
     # Helper functions to extract nodes and attributes
-    def select_elements(dom,names):
+    def select_elements(dom, names):
         """ returns a list of elements accoding to a list of hierarchical tag names, i.e. <names[0]><names[1]><names[2]>... """
-        elements = [ dom ]
+        elements = [dom]
         for name in names:
             child_elements = []
             for element in elements:
                 all_child_elements = element.childNodes
                 for child_element in all_child_elements:
-                    if (child_element.nodeName == name):
+                    if child_element.nodeName == name:
                         child_elements.append(child_element)
             elements = child_elements
         return elements
-    
-    def get_attribute_values(elements,name):
+
+    def get_attribute_values(elements, name):
         """ returns a list of attributes 'name' from a list of elements """
         attribute_values = []
         for element in elements:
@@ -478,41 +502,41 @@ def translate_config(config_filename,script_name='translate_config.py'):
                 if attribute.name == name:
                     attribute_values.append(attribute.value)
         return attribute_values
-    
+
     # Section i: 'name' attribute from all '/var/vars' elements
     def get_vars(dom_definition):
-        elements = select_elements(dom_definition,['definition','vars','var'])
-        attribute_values = get_attribute_values(elements,'name')
+        elements = select_elements(dom_definition, ["definition", "vars", "var"])
+        attribute_values = get_attribute_values(elements, "name")
         return attribute_values
-    
+
     # Section i: 'flagname' attribute from all '/definition/config/model' elements
     def get_config_model_flags(dom_definition):
-        elements = select_elements(dom_definition,['definition','config','model'])
+        elements = select_elements(dom_definition, ["definition", "config", "model"])
         model_flags = {}
         for element in elements:
-            flag = get_attribute_values([element],'flagname')[0]
-            model = get_attribute_values([element],'name')[0]
+            flag = get_attribute_values([element], "flagname")[0]
+            model = get_attribute_values([element], "name")[0]
             model_flags[flag] = model
         return model_flags
-    
+
     # Section ii: read 'name' attribute from all '/definition/build/make-arg' elements
     def get_build_make_args(dom_definition):
-        elements = select_elements(dom_definition,['definition','build','make-arg'])
-        attribute_values = get_attribute_values(elements,'name')
+        elements = select_elements(dom_definition, ["definition", "build", "make-arg"])
+        attribute_values = get_attribute_values(elements, "name")
         return attribute_values
-    
+
     # Section iii: read 'handle' attribute from all '/definition/build/macro' elements
     def get_build_macros(dom_definition):
-        elements = select_elements(dom_definition,['definition','build','macro'])
-        attribute_values = get_attribute_values(elements,'handle')
+        elements = select_elements(dom_definition, ["definition", "build", "macro"])
+        attribute_values = get_attribute_values(elements, "handle")
         return attribute_values
-    
+
     # Section iv: read 'name' attribute from all '/definition/testing/var' elements
     def get_testing_vars(dom_definition):
-        elements = select_elements(dom_definition,['definition','testing','var'])
-        attribute_values = get_attribute_values(elements,'name')
+        elements = select_elements(dom_definition, ["definition", "testing", "var"])
+        attribute_values = get_attribute_values(elements, "name")
         return attribute_values
-    
+
     # Section v: read 'name' attribute from '/definition/parameters/control/file';
     #           -> remove prefix 'data_', translate to <prefix>
     #      read 'name' attribute from all '/definition/parameters/control/file/namelist/param' elements
@@ -520,16 +544,18 @@ def translate_config(config_filename,script_name='translate_config.py'):
     #      translation: if in list of exceptions replace accordingly,
     #                  otherwise <var> -> <prefix>_<var>
     def get_control_params(dom_definition):
-        elements = select_elements(dom_definition,['definition','parameters','control','file'])
+        elements = select_elements(
+            dom_definition, ["definition", "parameters", "control", "file"]
+        )
         control_params = {}
         for element in elements:
-            filename = get_attribute_values([element],'name')[0]
-            name = filename.split('_')[1]
-            params = select_elements(element,['namelist','param'])
-            param_names = get_attribute_values(params,'name')
+            filename = get_attribute_values([element], "name")[0]
+            name = filename.split("_")[1]
+            params = select_elements(element, ["namelist", "param"])
+            param_names = get_attribute_values(params, "name")
             control_params[name] = param_names
         return control_params
-    
+
     # Section vi: read 'name' attribute from '/definition/control';
     #           -> translate to <prefix>, look up <array_convention>
     #      read 'name' attribute from all '/definition/control/file/namelist/paramArray/param' elements
@@ -541,21 +567,23 @@ def translate_config(config_filename,script_name='translate_config.py'):
     #      translation: if in list of exceptions replace accordingly,
     #                  otherwise construct <prefix>_<var><array_convention>n
     def get_control_param_arrays(dom_definition):
-        elements = select_elements(dom_definition,['definition','parameters','control','file'])
+        elements = select_elements(
+            dom_definition, ["definition", "parameters", "control", "file"]
+        )
         control_params = {}
         for element in elements:
-            filename = get_attribute_values([element],'name')[0]
-            name = filename.split('_')[1]
-            param_arrays = select_elements(element,['namelist','paramArray'])
+            filename = get_attribute_values([element], "name")[0]
+            name = filename.split("_")[1]
+            param_arrays = select_elements(element, ["namelist", "paramArray"])
             arrays = {}
             for param_array in param_arrays:
-                param_array_name = get_attribute_values([param_array],'name')[0]
-                params = select_elements(param_array,['param'])
-                param_indices = get_attribute_values(params,'index')
+                param_array_name = get_attribute_values([param_array], "name")[0]
+                params = select_elements(param_array, ["param"])
+                param_indices = get_attribute_values(params, "index")
                 arrays[param_array_name] = param_indices
             control_params[name] = arrays
         return control_params
-    
+
     # Section vii: read 'name' attribute from '/definition/parameter/model';
     #           -> translate to <prefix>
     #      read 'name' attribute from all '/definition/parameter/model/file/namelist/param' elements
@@ -563,15 +591,17 @@ def translate_config(config_filename,script_name='translate_config.py'):
     #      translation: if in list of exceptions replace accordingly,
     #                  otherwise <var> -> <prefix>_<var>
     def get_model_params(dom_definition):
-        elements = select_elements(dom_definition,['definition','parameters','model'])
+        elements = select_elements(
+            dom_definition, ["definition", "parameters", "model"]
+        )
         control_params = {}
         for element in elements:
-            name = get_attribute_values([element],'name')[0]
-            params = select_elements(element,['file','namelist','param'])
-            param_names = get_attribute_values(params,'name')
+            name = get_attribute_values([element], "name")[0]
+            params = select_elements(element, ["file", "namelist", "param"])
+            param_names = get_attribute_values(params, "name")
             control_params[name] = param_names
         return control_params
-    
+
     # Section viii: read 'name' attribute from '/definition/model';
     #           -> translate to <prefix>, look up <array_convention>
     #      read 'name' attribute from all '/definition/model/file/namelist/paramArray/param' elements
@@ -583,20 +613,22 @@ def translate_config(config_filename,script_name='translate_config.py'):
     #      translation: if in list of exceptions replace accordingly,
     #                  otherwise construct <prefix>_<var><array_convention>n
     def get_model_param_arrays(dom_definition):
-        elements = select_elements(dom_definition,['definition','parameters','model'])
+        elements = select_elements(
+            dom_definition, ["definition", "parameters", "model"]
+        )
         model_params = {}
         for element in elements:
-            name = get_attribute_values([element],'name')[0]
-            param_arrays = select_elements(element,['file','namelist','paramArray'])
+            name = get_attribute_values([element], "name")[0]
+            param_arrays = select_elements(element, ["file", "namelist", "paramArray"])
             arrays = {}
             for param_array in param_arrays:
-                param_array_name = get_attribute_values([param_array],'name')[0]
-                params = select_elements(param_array,['param'])
-                param_indices = get_attribute_values(params,'index')
+                param_array_name = get_attribute_values([param_array], "name")[0]
+                params = select_elements(param_array, ["param"])
+                param_indices = get_attribute_values(params, "index")
                 arrays[param_array_name] = param_indices
             model_params[name] = arrays
         return model_params
-    
+
     vars = get_vars(dom_definition)
     model_flags = get_config_model_flags(dom_definition)
     make_args = get_build_make_args(dom_definition)
@@ -606,32 +638,32 @@ def translate_config(config_filename,script_name='translate_config.py'):
     control_param_arrays = get_control_param_arrays(dom_definition)
     model_params = get_model_params(dom_definition)
     model_param_arrays = get_model_param_arrays(dom_definition)
-    
+
     dom_definition.unlink()
-    
+
     from xml.dom.minidom import getDOMImplementation
     from os.path import basename
     from datetime import date
-    
+
     # Create XML document for output of translated configuration
     dom_config = getDOMImplementation()
     job = dom_config.createDocument(None, "job", None)
     job_element = job.documentElement
-    job_element.setAttribute('creator',os.path.basename(script_name))
-    job_element.setAttribute('date',date.today().strftime("%Y-%m-%d"))
-    
+    job_element.setAttribute("creator", os.path.basename(script_name))
+    job_element.setAttribute("date", date.today().strftime("%Y-%m-%d"))
+
     # Helper function to add text nodes, which includes the translation of
     # variables by varref elements, and '/' separators by '<sep/>'
     # elements. Variables are identified if written in either of the
     # following forms '${<VAR>}', '$VAR ', '$VAR/', '$VAR (if at the end
     # of the variable text).
-    def translateAndAppendParameterValue(document,element,text):
-        re_sep = re.compile(r'\/')
-        re_var = re.compile(r'(.*?)\$({)?([^}\/]+)(})?(.*)')
+    def translateAndAppendParameterValue(document, element, text):
+        re_sep = re.compile(r"\/")
+        re_var = re.compile(r"(.*?)\$({)?([^}\/]+)(})?(.*)")
         text_parts = re_sep.split(text)
         for n in range(len(text_parts)):
-            if n>0:
-                sep_element = document.createElement('sep')
+            if n > 0:
+                sep_element = document.createElement("sep")
                 element.appendChild(sep_element)
             done = 0
             while not done:
@@ -645,123 +677,126 @@ def translate_config(config_filename,script_name='translate_config.py'):
                     if len(text_part.group(1)):
                         text_element = document.createTextNode(text_part.group(1))
                         element.appendChild(text_element)
-                    var_element = document.createElement('varref')
+                    var_element = document.createElement("varref")
                     text_element = document.createTextNode(text_part.group(3))
                     var_element.appendChild(text_element)
                     element.appendChild(var_element)
                     text_parts[n] = text_part.group(5)
         return None
-    
+
     # Apply translations and filter parameters from old-style
     # configuration for the individual sections to build a translated XML
     # config file
-    
-    
+
     # Section i: '/var/vars' elements
     #      no translation required
-    vars_element = job.createElement('vars')
+    vars_element = job.createElement("vars")
     for var in vars:
         old_config_key = var
-        if old_config.has_key(old_config_key):
-            element = job.createElement('var')
-            element.setAttribute('name',var)
-            translateAndAppendParameterValue(job,element,old_config[old_config_key])
+        if old_config_key in old_config:
+            element = job.createElement("var")
+            element.setAttribute("name", var)
+            translateAndAppendParameterValue(job, element, old_config[old_config_key])
             del old_config[old_config_key]
             vars_element.appendChild(element)
     job_element.appendChild(vars_element)
-    
+
     # Section ii: '/definition/config/model' elements
     #      translation: flag_* -> ma_flag_*
     #                   only parameters set to .true. are copied into
     #                   translated configuration, while parameters set to
     #                   .false. have to be absent in the translated
     #                   configuration
-    config_element = job.createElement('config')
+    config_element = job.createElement("config")
     for model_flag in model_flags.keys():
-        old_config_key = "_".join(['ma',model_flag])
-        if old_config.has_key(old_config_key):
-            if (old_config[old_config_key] == '.true.') or (old_config[old_config_key] == '.TRUE.'):
-                element = job.createElement('model')
-                element.setAttribute('name',model_flags[model_flag])
+        old_config_key = "_".join(["ma", model_flag])
+        if old_config_key in old_config:
+            if (old_config[old_config_key] == ".true.") or (
+                old_config[old_config_key] == ".TRUE."
+            ):
+                element = job.createElement("model")
+                element.setAttribute("name", model_flags[model_flag])
                 config_element.appendChild(element)
             del old_config[old_config_key]
     # Append config element
     job_element.appendChild(config_element)
-    
+
     # /job/build element needed for both sections iii and iv
-    build_element = job.createElement('build')
-    
+    build_element = job.createElement("build")
+
     # Section iii: '/definition/build/make-arg' elements
     #      no translation required
     for make_arg in make_args:
         old_config_key = make_arg
-        if old_config.has_key(old_config_key):
-            element = job.createElement('make-arg')
-            element.setAttribute('name',make_arg)
-            translateAndAppendParameterValue(job,element,old_config[old_config_key])
+        if old_config_key in old_config:
+            element = job.createElement("make-arg")
+            element.setAttribute("name", make_arg)
+            translateAndAppendParameterValue(job, element, old_config[old_config_key])
             del old_config[old_config_key]
             build_element.appendChild(element)
-    
+
     # Section iv: '/definition/build/macro' elements
     #      translation: value in the old configuration contains two parts,
     #      which have to be copied to the two different elements
     #      <identifier> and <replacement>
     for macro in macros:
         old_config_key = macro
-        if old_config.has_key(old_config_key):
-            element = job.createElement('macro')
-            element.setAttribute('handle',macro)
-            element.setAttribute('status','defined')
-            identifier_element = job.createElement('identifier')
-            replacement_element = job.createElement('replacement')
-            identifier, replacement = old_config[old_config_key].split('=')
-            translateAndAppendParameterValue(job,identifier_element,identifier)
-            translateAndAppendParameterValue(job,replacement_element,replacement)
+        if old_config_key in old_config:
+            element = job.createElement("macro")
+            element.setAttribute("handle", macro)
+            element.setAttribute("status", "defined")
+            identifier_element = job.createElement("identifier")
+            replacement_element = job.createElement("replacement")
+            identifier, replacement = old_config[old_config_key].split("=")
+            translateAndAppendParameterValue(job, identifier_element, identifier)
+            translateAndAppendParameterValue(job, replacement_element, replacement)
             element.appendChild(identifier_element)
             element.appendChild(replacement_element)
             build_element.appendChild(element)
             del old_config[old_config_key]
-    
+
     # Append build element
     job_element.appendChild(build_element)
-    
+
     # Section v: '/definition/testing/var' elements
     #      no translation required
-    testing_element = job.createElement('testing')
+    testing_element = job.createElement("testing")
     for testing_var in testing_vars:
         old_config_key = testing_var
-        if old_config.has_key(old_config_key):
-            element = job.createElement('var')
-            element.setAttribute('name',testing_var)
-            translateAndAppendParameterValue(job,element,old_config[old_config_key])
+        if old_config_key in old_config:
+            element = job.createElement("var")
+            element.setAttribute("name", testing_var)
+            translateAndAppendParameterValue(job, element, old_config[old_config_key])
             del old_config[old_config_key]
             testing_element.appendChild(element)
     job_element.appendChild(testing_element)
-    
+
     # /job/parameters element needed for all sections vi to ix
-    parameters_element = job.createElement('parameters')
-    
+    parameters_element = job.createElement("parameters")
+
     # /job/parameters/control element needed for both sections vi to ix
-    control_element = job.createElement('control')
-    
+    control_element = job.createElement("control")
+
     # Section vi: '/definition/parameters/control/file/namelist/param' elements
     #      translation: if in list of exceptions replace accordingly,
     #                  otherwise <var> -> <prefix>_<var>
     for key in control_params.keys():
         param_list = control_params[key]
         for param in param_list:
-            if exceptions.has_key(prefixes[key]) and exceptions[prefixes[key]].has_key(param):
+            if prefixes[key] in exceptions and param in exceptions[prefixes[key]]:
                 old_param = exceptions[prefixes[key]][param]
             else:
-                old_param = '_'.join([prefixes[key],param])
-            if old_config.has_key(old_param):
-                param_element = job.createElement('param')
-                param_element.setAttribute('name',param)
-                translateAndAppendParameterValue(job,param_element,old_config[old_param])
+                old_param = "_".join([prefixes[key], param])
+            if old_param in old_config:
+                param_element = job.createElement("param")
+                param_element.setAttribute("name", param)
+                translateAndAppendParameterValue(
+                    job, param_element, old_config[old_param]
+                )
                 del old_config[old_param]
                 control_element.appendChild(param_element)
     parameters_element.appendChild(control_element)
-    
+
     # Section vii: '/definition/control/file/namelist/paramArray/param' elements
     #      translation: if in list of exceptions replace accordingly,
     #                  otherwise construct <prefix>_<var><array_convention>n
@@ -771,75 +806,95 @@ def translate_config(config_filename,script_name='translate_config.py'):
             # only create paramArray once per parameter
             param_array_element_created = 0
             for index in param_dict[param]:
-                if exceptions.has_key(prefixes[key]) and exceptions[prefixes[key]].has_key(param+'('+index+')'):
-                    old_param = exceptions[prefixes[key]][param+'('+index+')']
+                if (
+                    prefixes[key] in exceptions
+                    and param + "(" + index + ")" in exceptions[prefixes[key]]
+                ):
+                    old_param = exceptions[prefixes[key]][param + "(" + index + ")"]
                 else:
-                    old_param = '_'.join([prefixes[key],param])+array_conventions[prefixes[key]]+index
-                if old_config.has_key(old_param):
+                    old_param = (
+                        "_".join([prefixes[key], param])
+                        + array_conventions[prefixes[key]]
+                        + index
+                    )
+                if old_param in old_config:
                     if not param_array_element_created:
-                        param_array_element = job.createElement('paramArray')
-                        param_array_element.setAttribute('name',param)
+                        param_array_element = job.createElement("paramArray")
+                        param_array_element.setAttribute("name", param)
                         param_array_element_created = 1
-                    param_element = job.createElement('param')
-                    param_element.setAttribute('index',index)
-                    translateAndAppendParameterValue(job,param_element,old_config[old_param])
+                    param_element = job.createElement("param")
+                    param_element.setAttribute("index", index)
+                    translateAndAppendParameterValue(
+                        job, param_element, old_config[old_param]
+                    )
                     del old_config[old_param]
                     param_array_element.appendChild(param_element)
             if param_array_element_created:
                 control_element.appendChild(param_array_element)
     parameters_element.appendChild(control_element)
-    
+
     for key in set(model_params.keys()).union(model_param_arrays.keys()):
 
-    # /job/parameters/model element needed for both sections viii to ix, but will only be created when really required
+        # /job/parameters/model element needed for both sections viii to ix, but will only be created when really required
         model_element_created = 0
-    
-    # Section viii: '/definition/parameter/model/file/namelist/param' elements
-    #      translation: if in list of exceptions replace accordingly,
-    #                  otherwise <var> -> <prefix>_<var>
-        if model_params.has_key(key):
+
+        # Section viii: '/definition/parameter/model/file/namelist/param' elements
+        #      translation: if in list of exceptions replace accordingly,
+        #                  otherwise <var> -> <prefix>_<var>
+        if key in model_params:
             param_list = model_params[key]
             for param in param_list:
-                if exceptions.has_key(prefixes[key]) and exceptions[prefixes[key]].has_key(param):
+                if prefixes[key] in exceptions and param in exceptions[prefixes[key]]:
                     old_param = exceptions[prefixes[key]][param]
                 else:
-                    old_param = '_'.join([prefixes[key],param])
-                if old_config.has_key(old_param):
+                    old_param = "_".join([prefixes[key], param])
+                if old_param in old_config:
                     if not model_element_created:
-                        model_element = job.createElement('model')
-                        model_element.setAttribute('name',key)
+                        model_element = job.createElement("model")
+                        model_element.setAttribute("name", key)
                         model_element_created = 1
-                    param_element = job.createElement('param')
-                    param_element.setAttribute('name',param)
-                    translateAndAppendParameterValue(job,param_element,old_config[old_param])
+                    param_element = job.createElement("param")
+                    param_element.setAttribute("name", param)
+                    translateAndAppendParameterValue(
+                        job, param_element, old_config[old_param]
+                    )
                     del old_config[old_param]
                     model_element.appendChild(param_element)
-    
-    # Section ix: '/definition/model/file/namelist/paramArray/param' elements
-    #      translation: if in list of exceptions replace accordingly,
-    #                  otherwise construct <prefix>_<var><array_convention>n
-        if model_param_arrays.has_key(key):
+
+        # Section ix: '/definition/model/file/namelist/paramArray/param' elements
+        #      translation: if in list of exceptions replace accordingly,
+        #                  otherwise construct <prefix>_<var><array_convention>n
+        if key in model_param_arrays:
             param_dict = model_param_arrays[key]
             for param in param_dict.keys():
                 # only create paramArray once per parameter
                 param_array_element_created = 0
                 for index in param_dict[param]:
-                    if exceptions.has_key(prefixes[key]) and exceptions[prefixes[key]].has_key(param+'('+index+')'):
-                        old_param = exceptions[prefixes[key]][param+'('+index+')']
+                    if (
+                        prefixes[key] in exceptions
+                        and param + "(" + index + ")" in exceptions[prefixes[key]]
+                    ):
+                        old_param = exceptions[prefixes[key]][param + "(" + index + ")"]
                     else:
-                        old_param = '_'.join([prefixes[key],param])+array_conventions[prefixes[key]]+index
-                    if old_config.has_key(old_param):
+                        old_param = (
+                            "_".join([prefixes[key], param])
+                            + array_conventions[prefixes[key]]
+                            + index
+                        )
+                    if old_param in old_config:
                         if not model_element_created:
-                            model_element = job.createElement('model')
-                            model_element.setAttribute('name',key)
+                            model_element = job.createElement("model")
+                            model_element.setAttribute("name", key)
                             model_element_created = 1
                         if not param_array_element_created:
-                            param_array_element = job.createElement('paramArray')
-                            param_array_element.setAttribute('name',param)
+                            param_array_element = job.createElement("paramArray")
+                            param_array_element.setAttribute("name", param)
                             param_array_element_created = 1
-                        param_element = job.createElement('param')
-                        param_element.setAttribute('index',index)
-                        translateAndAppendParameterValue(job,param_element,old_config[old_param])
+                        param_element = job.createElement("param")
+                        param_element.setAttribute("index", index)
+                        translateAndAppendParameterValue(
+                            job, param_element, old_config[old_param]
+                        )
                         del old_config[old_param]
                         param_array_element.appendChild(param_element)
                 if param_array_element_created:
@@ -847,24 +902,27 @@ def translate_config(config_filename,script_name='translate_config.py'):
 
         if model_element_created:
             parameters_element.appendChild(model_element)
-    
+
     job_element.appendChild(parameters_element)
     xml_config = job.toprettyxml(encoding="UTF-8")
 
     # all matched key-value pairs have been removed from 'old_config'
     # as the translation has proceeded.
-    if old_config.has_key('BUILDTEST_NAME'):
-        del old_config['BUILDTEST_NAME']
+    if "BUILDTEST_NAME" not in old_config:
+        del old_config["BUILDTEST_NAME"]
     # If there are any entries left in 'old-config', then it is
     # an unrecognised setting and so the configuration file is
     # bugged (perhaps just a typo).
     # To be safe, lets halt with an error in that case
     if len(old_config) != 0:
-        sys.stderr.write("Error: unrecognised settings in config file (perhaps a typo?):\n")
-        sys.stderr.write(repr(old_config)+"\n")
+        sys.stderr.write(
+            "Error: unrecognised settings in config file (perhaps a typo?):\n"
+        )
+        sys.stderr.write(repr(old_config) + "\n")
         sys.exit(1)
 
     return xml_config
+
 
 #
 # end function translate_config
@@ -872,8 +930,8 @@ def translate_config(config_filename,script_name='translate_config.py'):
 
 if __name__ == "__main__":
     import sys
-    if len(sys.argv) != 2:
-        print "Usage: translate_config.py <old-style config file>"
-        sys.exit(1)
-    print translate_config(sys.argv[1],sys.argv[0])
 
+    if len(sys.argv) != 2:
+        print("Usage: translate_config.py <old-style config file>")
+        sys.exit(1)
+    print(translate_config(sys.argv[1], sys.argv[0]))


### PR DESCRIPTION
Small changes in Python files in the `genie-main` folder to comply with Python3 directives:

- update `print` statements
- `has_key` has been deprecated in Python 3.0. so use the `in` alternative