### PR TITLE
_DEV_ECOGEM -> master

### DIFF
--- a/genie-ecogem/src/fortran/ecogem_data.f90
+++ b/genie-ecogem/src/fortran/ecogem_data.f90
@@ -170,6 +170,7 @@ CONTAINS
        print*,'--- DATA SAVING: MISC ------------------------------'
        print*,'Restart in netCDF format?                           : ',ctrl_ncrst
        print*,'netCDF restart file name                            : ',trim(par_ncrst_name)
+       print*,'timeseries locations file name                      : ',trim(par_ecogem_timeseries_file)
     end if ! end ctrl_debug_eco_init
 66  format(a56,l2)
 67  format(a56,i2)
@@ -815,7 +816,7 @@ CONTAINS
     loc_lat(1:n_j) = fun_get_grid_lat(n_j)
 
     ! check file format and determine number of lines of data
-    loc_filename = TRIM(par_indir_name)//"/timeseries_sites.eco"!//TRIM(par_ecogem_timeseries_file)
+    loc_filename = TRIM(par_indir_name)//"/"//TRIM(par_ecogem_timeseries_file)
     CALL sub_check_fileformat(loc_filename,loc_n_elements,loc_n_start)
 
     ! open file pipe

--- a/genie-ecogem/src/fortran/ecogem_lib.f90
+++ b/genie-ecogem/src/fortran/ecogem_lib.f90
@@ -157,6 +157,8 @@ MODULE ecogem_lib
   NAMELIST /ini_ecogem_nml/nsubtime!
   CHARACTER(len=127)::par_ecogem_plankton_file
   NAMELIST /ini_ecogem_nml/par_ecogem_plankton_file
+  CHARACTER(len=127)::par_ecogem_timeseries_file
+  NAMELIST /ini_ecogem_nml/par_ecogem_timeseries_file
   ! JDW force T fields
   logical::ctrl_force_T
   namelist /ini_ecogem_nml/ctrl_force_T

--- a/genie-ecogem/src/fortran/end_ecogem.f90
+++ b/genie-ecogem/src/fortran/end_ecogem.f90
@@ -27,11 +27,12 @@ SUBROUTINE end_ecogem()
   ! ---------------------------------------------------------- !
   ! SAVE DATA: 3-D netCDF
   ! ---------------------------------------------------------- !
-  if (ctrl_debug_end > 0) print*,'WRITE 3D netCDF OUTPUT'
-  call sub_update_netcdf(const_real_zero,3)
-  call sub_save_netcdf_3d()
-  call sub_closefile(ncout3d_iou)
-  ncout3d_ntrec = ncout3d_ntrec + 1
+  ! NOTE: 3D data is not currently saved, so disable nc file creation
+  !if (ctrl_debug_end > 0) print*,'WRITE 3D netCDF OUTPUT'
+  !call sub_update_netcdf(const_real_zero,3)
+  !call sub_save_netcdf_3d()
+  !call sub_closefile(ncout3d_iou)
+  !ncout3d_ntrec = ncout3d_ntrec + 1
 101 continue
 
 

--- a/genie-ecogem/src/fortran/initialise_ecogem.f90
+++ b/genie-ecogem/src/fortran/initialise_ecogem.f90
@@ -364,9 +364,10 @@ SUBROUTINE initialise_ecogem(    &
   call sub_init_netcdf(trim(string_ncout2d),loc_iou,2)
   ncout2d_iou = loc_iou
   ncout2d_ntrec = 0
-  call sub_init_netcdf(trim(string_ncout3d),loc_iou,3)
-  ncout3d_iou = loc_iou
-  ncout3d_ntrec = 0
+  ! NOTE: 3D data is not currently saved, so disable nc file creation
+  !call sub_init_netcdf(trim(string_ncout3d),loc_iou,3)
+  !ncout3d_iou = loc_iou
+  !ncout3d_ntrec = 0
   ! ---------------------------------------------------------- ! LOAD RE-START
   IF (ctrl_continuing) then
      IF (ctrl_debug_init > 0) print*,'LOAD RE-START'

--- a/genie-main/src/xml-config/xml/definition.xml
+++ b/genie-main/src/xml-config/xml/definition.xml
@@ -8855,6 +8855,10 @@ par_bio_red_PC_alpha2 scales the offset of 6.0e-3 of Galbraith & Martiny, 2015 C
 			<value datatype="string">temperature.dat</value>
 		     			<description>Input file for forcing temperature in ecogem</description>
                     </param>
+                    <param name="par_ecogem_timeseries_file">
+			<value datatype="string">timeseries_sites.eco</value>
+		     			<description>timeseries locations file name</description>
+                    </param>
                 </namelist>
             </file>
         </model>

--- a/genie-userconfigs/LABS/EXP.8.1
+++ b/genie-userconfigs/LABS/EXP.8.1
@@ -110,6 +110,8 @@ eg_par_bio_red_POC_CaCO3     = 0.0285 # underlying export CaCO3 as a proportion 
 bg_par_data_save_level=7
 # force time-slice save at run end only
 bg_par_infile_slice_name='save_timeslice_NONE.dat'
+# turn off ECOGEM location-specific time-series saving
+eg_par_ecogem_timeseries_file='timeseries_sites_NONE.eco'
 #
 # *** FORCINGS ******************************************************
 #


### PR DESCRIPTION
simplified ECOGEM output -- disabled 3D netCDF file creation because nothing is currently saved, and added the option to provide a filename for site-specific time-series saving that lists no sites (disabling time-series file creation)); no change to default saving excepting the absence of the 3D nc file